### PR TITLE
docs(examples): change length of tree example in demo

### DIFF
--- a/_examples/demo/main.go
+++ b/_examples/demo/main.go
@@ -39,7 +39,6 @@ func main() {
 func installedTree() {
 	leveledList := pterm.LeveledList{
 		pterm.LeveledListItem{Level: 0, Text: "C:"},
-		pterm.LeveledListItem{Level: 1, Text: "Users"},
 		pterm.LeveledListItem{Level: 1, Text: "Go"},
 		pterm.LeveledListItem{Level: 1, Text: "Windows"},
 		pterm.LeveledListItem{Level: 1, Text: "Programs"},
@@ -52,7 +51,6 @@ func installedTree() {
 			leveledList = append(leveledList, pterm.LeveledListItem{Level: 3, Text: "pseudo-Tabs"})
 			leveledList = append(leveledList, pterm.LeveledListItem{Level: 3, Text: "pseudo-Extensions"})
 			leveledList = append(leveledList, pterm.LeveledListItem{Level: 4, Text: "Refined GitHub"})
-			leveledList = append(leveledList, pterm.LeveledListItem{Level: 4, Text: "GitHub Notifier"})
 			leveledList = append(leveledList, pterm.LeveledListItem{Level: 4, Text: "GitHub Dark Theme"})
 			leveledList = append(leveledList, pterm.LeveledListItem{Level: 3, Text: "pseudo-Bookmarks"})
 			leveledList = append(leveledList, pterm.LeveledListItem{Level: 4, Text: "PTerm"})


### PR DESCRIPTION
### Description
Changed the length of the tree example in the demo to fit in one window.

### Scope
> What is affected by this pull request?

- [ ] Bug Fix
- [ ] New Feature
- [x] Documentation
- [ ] Other

### To-Do Checklist
- [x] I tested my changes
- [ ] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [ ] I have added tests for my newly created methods
