### PR TITLE
docs(examples): change color of `BigLetter` P of PTerm to `FgLightCyan`

### DIFF
--- a/_examples/demo/main.go
+++ b/_examples/demo/main.go
@@ -116,7 +116,7 @@ func pseudoApplicationHeader() *pterm.TextPrinter {
 
 func introScreen() {
 	pterm.DefaultBigText.WithLetters(
-		pterm.NewLettersFromStringWithStyle("P", pterm.NewStyle(pterm.FgCyan)),
+		pterm.NewLettersFromStringWithStyle("P", pterm.NewStyle(pterm.FgLightCyan)),
 		pterm.NewLettersFromStringWithStyle("Term", pterm.NewStyle(pterm.FgLightMagenta))).
 		Render()
 


### PR DESCRIPTION
### Description
Changed the color of `BigText` P in PTerm to FgLightCyan to match the color of the other letters.

### Scope
> What is affected by this pull request?

- [ ] Bug Fix
- [ ] New Feature
- [x] Documentation
- [ ] Other

### To-Do Checklist
- [x] I tested my changes
- [ ] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [ ] I have added tests for my newly created methods
