### PR TITLE
fix(centerprinter): make centerprinter func return pointer

### DIFF
--- a/center_printer.go
+++ b/center_printer.go
@@ -17,10 +17,10 @@ type CenterPrinter struct {
 }
 
 // WithCenterEachLineSeparately centers each line separately.
-func (p CenterPrinter) WithCenterEachLineSeparately(b ...bool) CenterPrinter {
+func (p CenterPrinter) WithCenterEachLineSeparately(b ...bool) *CenterPrinter {
 	bt := internal.WithBoolean(b)
 	p.CenterEachLineSeparately = bt
-	return p
+	return &p
 }
 
 // Sprint formats using the default formats for its operands and returns the resulting string.


### PR DESCRIPTION
BREAKING CHANGE: make centerprinter func `WithCenterEachLineSeparately` return a pointer of centerprinter

### Description
Made centerprinter func `WithCenterEachLineSeparately` return a pointer.

### Scope
> What is affected by this pull request?

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

### Related Issue
Fixes #114 


### To-Do Checklist
- [x] I tested my changes
- [x] I have commented every method that I created/changed
- [x] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods
