### PR TITLE
fix: correct `pterm.Println()` behaviour to fit to `fmt.Println()`

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="CommitMessageInspectionProfile">
     <profile version="1.0">
+      <inspection_tool class="GrazieCommit" enabled="true" level="TYPO" enabled_by_default="true" />
       <inspection_tool class="SubjectBodySeparation" enabled="true" level="WARNING" enabled_by_default="true" />
     </profile>
   </component>

--- a/basic_text_printer.go
+++ b/basic_text_printer.go
@@ -1,5 +1,7 @@
 package pterm
 
+import "fmt"
+
 var (
 	// DefaultBasicText returns a default BasicTextPrinter, which can be used to print text as is.
 	// No default style is present for BasicTextPrinter.
@@ -29,7 +31,8 @@ func (p BasicTextPrinter) Sprint(a ...interface{}) string {
 // Sprintln formats using the default formats for its operands and returns the resulting string.
 // Spaces are always added between operands and a newline is appended.
 func (p BasicTextPrinter) Sprintln(a ...interface{}) string {
-	return Sprintln(p.Sprint(a...))
+	str := fmt.Sprintln(a...)
+	return Sprintln(p.Sprint(str))
 }
 
 // Sprintf formats according to a format specifier and returns the resulting string.
@@ -50,7 +53,7 @@ func (p *BasicTextPrinter) Print(a ...interface{}) *TextPrinter {
 // Spaces are always added between operands and a newline is appended.
 // It returns the number of bytes written and any write error encountered.
 func (p *BasicTextPrinter) Println(a ...interface{}) *TextPrinter {
-	Println(p.Sprint(a...))
+	Print(p.Sprintln(a...))
 	tp := TextPrinter(p)
 	return &tp
 }

--- a/color.go
+++ b/color.go
@@ -140,7 +140,8 @@ type Color uint8
 // Spaces are always added between operands and a newline is appended.
 // Input will be colored with the parent Color.
 func (c Color) Sprintln(a ...interface{}) string {
-	return c.Sprint(a...) + "\n"
+	str := fmt.Sprintln(a...)
+	return c.Sprint(str)
 }
 
 // Sprint formats using the default formats for its operands and returns the resulting string.

--- a/header_printer.go
+++ b/header_printer.go
@@ -83,7 +83,7 @@ func (p HeaderPrinter) Sprint(a ...interface{}) string {
 // Sprintln formats using the default formats for its operands and returns the resulting string.
 // Spaces are always added between operands and a newline is appended.
 func (p HeaderPrinter) Sprintln(a ...interface{}) string {
-	return Sprint(p.Sprint(a...) + "\n")
+	return p.Sprint(strings.TrimSuffix(Sprintln(a...), "\n"))
 }
 
 // Sprintf formats according to a format specifier and returns the resulting string.
@@ -104,7 +104,7 @@ func (p *HeaderPrinter) Print(a ...interface{}) *TextPrinter {
 // Spaces are always added between operands and a newline is appended.
 // It returns the number of bytes written and any write error encountered.
 func (p *HeaderPrinter) Println(a ...interface{}) *TextPrinter {
-	Println(p.Sprint(a...))
+	Print(p.Sprintln(a...))
 	tp := TextPrinter(p)
 	return &tp
 }

--- a/paragraph_printer.go
+++ b/paragraph_printer.go
@@ -47,7 +47,7 @@ func (p ParagraphPrinter) Sprint(a ...interface{}) string {
 // Sprintln formats using the default formats for its operands and returns the resulting string.
 // Spaces are always added between operands and a newline is appended.
 func (p ParagraphPrinter) Sprintln(a ...interface{}) string {
-	return Sprintln(p.Sprint(a...))
+	return p.Sprint(Sprintln(a...)) + "\n"
 }
 
 // Sprintf formats according to a format specifier and returns the resulting string.
@@ -68,7 +68,7 @@ func (p *ParagraphPrinter) Print(a ...interface{}) *TextPrinter {
 // Spaces are always added between operands and a newline is appended.
 // It returns the number of bytes written and any write error encountered.
 func (p *ParagraphPrinter) Println(a ...interface{}) *TextPrinter {
-	Println(p.Sprint(a...))
+	Print(p.Sprintln(a...))
 	tp := TextPrinter(p)
 	return &tp
 }

--- a/prefix_printer.go
+++ b/prefix_printer.go
@@ -1,6 +1,7 @@
 package pterm
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/pterm/pterm/internal"
@@ -178,7 +179,8 @@ func (p PrefixPrinter) Sprintln(a ...interface{}) string {
 	if p.Debugger && !PrintDebugMessages {
 		return ""
 	}
-	return p.Sprint(a...) + "\n"
+	str := fmt.Sprintln(a...)
+	return p.Sprint(str)
 }
 
 // Sprintf formats according to a format specifier and returns the resulting string.

--- a/rgb.go
+++ b/rgb.go
@@ -93,7 +93,7 @@ func (p RGB) Sprint(a ...interface{}) string {
 // Sprintln formats using the default formats for its operands and returns the resulting string.
 // Spaces are always added between operands and a newline is appended.
 func (p RGB) Sprintln(a ...interface{}) string {
-	return Sprintln(p.Sprint(a...))
+	return p.Sprint(Sprintln(a...))
 }
 
 // Sprintf formats according to a format specifier and returns the resulting string.
@@ -114,7 +114,7 @@ func (p RGB) Print(a ...interface{}) *TextPrinter {
 // Spaces are always added between operands and a newline is appended.
 // It returns the number of bytes written and any write error encountered.
 func (p RGB) Println(a ...interface{}) *TextPrinter {
-	Println(p.Sprint(a...))
+	Print(p.Sprintln(a...))
 	tp := TextPrinter(p)
 	return &tp
 }

--- a/section_printer.go
+++ b/section_printer.go
@@ -1,6 +1,9 @@
 package pterm
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // DefaultSection is the default section printer.
 var DefaultSection = SectionPrinter{
@@ -80,7 +83,8 @@ func (p SectionPrinter) Sprint(a ...interface{}) string {
 // Sprintln formats using the default formats for its operands and returns the resulting string.
 // Spaces are always added between operands and a newline is appended.
 func (p SectionPrinter) Sprintln(a ...interface{}) string {
-	return Sprintln(p.Sprint(a...))
+	str := fmt.Sprintln(a...)
+	return Sprint(p.Sprint(str))
 }
 
 // Sprintf formats according to a format specifier and returns the resulting string.
@@ -101,7 +105,7 @@ func (p *SectionPrinter) Print(a ...interface{}) *TextPrinter {
 // Spaces are always added between operands and a newline is appended.
 // It returns the number of bytes written and any write error encountered.
 func (p *SectionPrinter) Println(a ...interface{}) *TextPrinter {
-	Println(p.Sprint(a...))
+	Print(p.Sprintln(a...))
 	tp := TextPrinter(p)
 	return &tp
 }


### PR DESCRIPTION
### Description
Corrected behavior of `Println` in every `TextPrinter`.

### Scope
> What is affected by this pull request?

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

### Related Issue
Fixes #160


### To-Do Checklist
- [x] I tested my changes
- [x] I have commented every method that I created/changed
- [x] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods
