### PR TITLE
feat(prefixprinter): Add option to show line number of caller

### DIFF
--- a/_examples/prefix/main.go
+++ b/_examples/prefix/main.go
@@ -6,11 +6,12 @@ func main() {
 	// Enable debug messages.
 	pterm.EnableDebugMessages()
 
-	pterm.Debug.Println("Hello, World!")   // Print Debug.
-	pterm.Info.Println("Hello, World!")    // Print Info.
-	pterm.Success.Println("Hello, World!") // Print Success.
-	pterm.Warning.Println("Hello, World!") // Print Warning.
-	pterm.Error.Println("Hello, World!")   // Print Error.
+	pterm.Debug.Println("Hello, World!")                                             // Print Debug.
+	pterm.Info.Println("Hello, World!")                                              // Print Info.
+	pterm.Success.Println("Hello, World!")                                           // Print Success.
+	pterm.Warning.Println("Hello, World!")                                           // Print Warning.
+	pterm.Error.Println("Errors show the file and linenumber inside the terminal!")  // Print Error.
+	pterm.Info.WithShowLineNumber().Println("Other PrefixPrinters can do that too!") // Print Error.
 	// Temporarily set Fatal to false, so that the CI won't crash.
 	pterm.Fatal.WithFatal(false).Println("Hello, World!") // Print Fatal.
 }

--- a/prefix_printer_test.go
+++ b/prefix_printer_test.go
@@ -99,6 +99,16 @@ func TestPrefixPrinter_WithFatal(t *testing.T) {
 	}
 }
 
+func TestPrefixPrinter_WithShowLineNumber(t *testing.T) {
+	for _, p := range prefixPrinters {
+		t.Run("", func(t *testing.T) {
+			p2 := p.WithShowLineNumber()
+
+			assert.Equal(t, true, p2.ShowLineNumber)
+		})
+	}
+}
+
 func TestPrefixPrinter_WithMessageStyle(t *testing.T) {
 	for _, p := range prefixPrinters {
 		t.Run("", func(t *testing.T) {


### PR DESCRIPTION
### Description
Adds an option to `PrefixPrinter`, which outputs the line number and filename, where the `PrefixPrinter` is used.

### Scope
> What is affected by this pull request?

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Other


### To-Do Checklist
- [x] I tested my changes
- [x] I have commented every method that I created/changed
- [x] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods
