### PR TITLE
fix(bigtext): fix height of some characters #180

### DIFF
--- a/bigtext_printer.go
+++ b/bigtext_printer.go
@@ -416,8 +416,7 @@ var DefaultBigText = BigTextPrinter{
 ██      
 ███████ 
      ██ 
-███████ 
-       `,
+███████`,
 		"6": ` ██████  
 ██       
 ███████  
@@ -437,8 +436,7 @@ var DefaultBigText = BigTextPrinter{
 ██   ██ 
  ██████ 
      ██ 
- █████  
-        `,
+ █████ `,
 		" ": "    ",
 		"!": `██ 
 ██ 
@@ -460,8 +458,7 @@ var DefaultBigText = BigTextPrinter{
    ██  
   ██   
  ██    
-██     
-       `,
+██   `,
 		"(": ` ██ 
 ██  
 ██  
@@ -502,7 +499,6 @@ var DefaultBigText = BigTextPrinter{
 █████ 
       
       
-      
      `,
 		"<": `  ██ 
  ██  
@@ -529,5 +525,15 @@ var DefaultBigText = BigTextPrinter{
         
         
 ███████ `,
+		":": `   
+██ 
+   
+   
+██ `,
+		"°": ` ████  
+██  ██ 
+ ████  
+       
+      `,
 	},
 }

--- a/bigtext_printer_test.go
+++ b/bigtext_printer_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"io"
 	"testing"
+	"strings"
 )
 
 func TestBigTextPrinterNilPrint(t *testing.T) {
@@ -93,4 +94,13 @@ func TestNewLettersFromTextWithStyle(t *testing.T) {
 	p := NewLettersFromStringWithStyle("ab", NewStyle(FgRed, BgBlue, Bold))
 
 	assert.Equal(t, e, p)
+}
+
+func TestDefaultLettersMaxHeight(t *testing.T) {
+	maxHeight := 5
+	chars := DefaultBigText.BigCharacters
+	for s, l := range(chars) {
+		h := strings.Count(l, "\n")
+		assert.LessOrEqualf(t, h, maxHeight, "'%s' is too high", s)
+	}
 }


### PR DESCRIPTION
### Description
I've noticed that numbers 5 and 9 are higher than others. Made a test and also found two more symbols with higher heights.
Also added two more symbols - is it ok to include them in the same PR?

### Scope
> What is affected by this pull request?

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

### Related Issue
Fixes #


### To-Do Checklist
- [x] I tested my changes
- [ ] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods
