### PR TITLE
`PrefixPrinter` cannot exceed terminal width anymore

### DIFF
--- a/prefix_printer.go
+++ b/prefix_printer.go
@@ -139,7 +139,7 @@ func (p PrefixPrinter) WithDebugger(b ...bool) *PrefixPrinter {
 // Sprint formats using the default formats for its operands and returns the resulting string.
 // Spaces are added between operands when neither is a string.
 func (p *PrefixPrinter) Sprint(a ...interface{}) string {
-	m := Sprint(a...)
+	m := DefaultParagraph.WithMaxWidth(GetTerminalWidth() - len(p.Prefix.Text)).Sprint(a...)
 	if p.Debugger && !PrintDebugMessages {
 		return ""
 	}


### PR DESCRIPTION
Fixes: #177

### Description
`PrefixPrinter` cannot exceed terminal width anymore

### Scope
> What is affected by this pull request?

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

### Related Issue
Fixes #177


### To-Do Checklist
- [x] I tested my changes
