### PR TITLE
add `Sprintfln` and `Printfln` functions for all printers

### DIFF
--- a/basic_text_printer.go
+++ b/basic_text_printer.go
@@ -40,6 +40,12 @@ func (p BasicTextPrinter) Sprintf(format string, a ...interface{}) string {
 	return p.Sprint(Sprintf(format, a...))
 }
 
+// Sprintfln formats according to a format specifier and returns the resulting string.
+// Spaces are always added between operands and a newline is appended.
+func (p BasicTextPrinter) Sprintfln(format string, a ...interface{}) string {
+	return p.Sprint(Sprintf(format, a...) + "\n")
+}
+
 // Print formats using the default formats for its operands and writes to standard output.
 // Spaces are added between operands when neither is a string.
 // It returns the number of bytes written and any write error encountered.
@@ -62,6 +68,15 @@ func (p *BasicTextPrinter) Println(a ...interface{}) *TextPrinter {
 // It returns the number of bytes written and any write error encountered.
 func (p *BasicTextPrinter) Printf(format string, a ...interface{}) *TextPrinter {
 	Print(p.Sprintf(format, a...))
+	tp := TextPrinter(p)
+	return &tp
+}
+
+// Printfln formats according to a format specifier and writes to standard output.
+// Spaces are always added between operands and a newline is appended.
+// It returns the number of bytes written and any write error encountered.
+func (p *BasicTextPrinter) Printfln(format string, a ...interface{}) *TextPrinter {
+	Print(p.Sprintfln(format, a...))
 	tp := TextPrinter(p)
 	return &tp
 }

--- a/basic_text_printer.go
+++ b/basic_text_printer.go
@@ -43,7 +43,7 @@ func (p BasicTextPrinter) Sprintf(format string, a ...interface{}) string {
 // Sprintfln formats according to a format specifier and returns the resulting string.
 // Spaces are always added between operands and a newline is appended.
 func (p BasicTextPrinter) Sprintfln(format string, a ...interface{}) string {
-	return p.Sprint(Sprintf(format, a...) + "\n")
+	return p.Sprintf(format, a...) + "\n"
 }
 
 // Print formats using the default formats for its operands and writes to standard output.

--- a/basic_text_printer_test.go
+++ b/basic_text_printer_test.go
@@ -28,6 +28,12 @@ func TestBasicTextPrinterPrintMethods(t *testing.T) {
 		})
 	})
 
+	t.Run("Printfln", func(t *testing.T) {
+		internal.TestPrintflnContains(t, func(w io.Writer, format string, a interface{}) {
+			p.Printfln(format, a)
+		})
+	})
+
 	t.Run("Println", func(t *testing.T) {
 		internal.TestPrintlnContains(t, func(w io.Writer, a interface{}) {
 			p.Println(a)
@@ -43,6 +49,12 @@ func TestBasicTextPrinterPrintMethods(t *testing.T) {
 	t.Run("Sprintf", func(t *testing.T) {
 		internal.TestSprintfContains(t, func(format string, a interface{}) string {
 			return p.Sprintf(format, a)
+		})
+	})
+
+	t.Run("Sprintfln", func(t *testing.T) {
+		internal.TestSprintflnContains(t, func(format string, a interface{}) string {
+			return p.Sprintfln(format, a)
 		})
 	})
 

--- a/box_printer.go
+++ b/box_printer.go
@@ -166,6 +166,12 @@ func (p BoxPrinter) Sprintf(format string, a ...interface{}) string {
 	return p.Sprint(Sprintf(format, a...))
 }
 
+// Sprintfln formats according to a format specifier and returns the resulting string.
+// Spaces are always added between operands and a newline is appended.
+func (p BoxPrinter) Sprintfln(format string, a ...interface{}) string {
+	return p.Sprint(Sprintf(format, a...) + "\n")
+}
+
 // Print formats using the default formats for its operands and writes to standard output.
 // Spaces are added between operands when neither is a string.
 // It returns the number of bytes written and any write error encountered.
@@ -188,6 +194,15 @@ func (p BoxPrinter) Println(a ...interface{}) *TextPrinter {
 // It returns the number of bytes written and any write error encountered.
 func (p BoxPrinter) Printf(format string, a ...interface{}) *TextPrinter {
 	Print(p.Sprintf(format, a...))
+	tp := TextPrinter(p)
+	return &tp
+}
+
+// Printfln formats according to a format specifier and writes to standard output.
+// Spaces are always added between operands and a newline is appended.
+// It returns the number of bytes written and any write error encountered.
+func (p BoxPrinter) Printfln(format string, a ...interface{}) *TextPrinter {
+	Print(p.Sprintfln(format, a...))
 	tp := TextPrinter(p)
 	return &tp
 }

--- a/box_printer.go
+++ b/box_printer.go
@@ -169,7 +169,7 @@ func (p BoxPrinter) Sprintf(format string, a ...interface{}) string {
 // Sprintfln formats according to a format specifier and returns the resulting string.
 // Spaces are always added between operands and a newline is appended.
 func (p BoxPrinter) Sprintfln(format string, a ...interface{}) string {
-	return p.Sprint(Sprintf(format, a...) + "\n")
+	return p.Sprintf(format, a...) + "\n"
 }
 
 // Print formats using the default formats for its operands and writes to standard output.

--- a/box_printer_test.go
+++ b/box_printer_test.go
@@ -29,6 +29,12 @@ func TestBoxPrinterPrintMethods(t *testing.T) {
 		})
 	})
 
+	t.Run("Printfln", func(t *testing.T) {
+		internal.TestPrintflnContains(t, func(w io.Writer, format string, a interface{}) {
+			p.Printfln(format, a)
+		})
+	})
+
 	t.Run("Println", func(t *testing.T) {
 		internal.TestPrintlnContains(t, func(w io.Writer, a interface{}) {
 			p.Println(a)
@@ -44,6 +50,12 @@ func TestBoxPrinterPrintMethods(t *testing.T) {
 	t.Run("Sprintf", func(t *testing.T) {
 		internal.TestSprintfContains(t, func(format string, a interface{}) string {
 			return p.Sprintf(format, a)
+		})
+	})
+
+	t.Run("Sprintfln", func(t *testing.T) {
+		internal.TestSprintflnContains(t, func(format string, a interface{}) string {
+			return p.Sprintfln(format, a)
 		})
 	})
 

--- a/center_printer.go
+++ b/center_printer.go
@@ -69,7 +69,7 @@ func (p CenterPrinter) Sprintf(format string, a ...interface{}) string {
 // Sprintfln formats according to a format specifier and returns the resulting string.
 // Spaces are always added between operands and a newline is appended.
 func (p CenterPrinter) Sprintfln(format string, a ...interface{}) string {
-	return p.Sprint(Sprintf(format, a...) + "\n")
+	return p.Sprintf(format, a...) + "\n"
 }
 
 // Print formats using the default formats for its operands and writes to standard output.

--- a/center_printer.go
+++ b/center_printer.go
@@ -66,6 +66,12 @@ func (p CenterPrinter) Sprintf(format string, a ...interface{}) string {
 	return p.Sprint(Sprintf(format, a...))
 }
 
+// Sprintfln formats according to a format specifier and returns the resulting string.
+// Spaces are always added between operands and a newline is appended.
+func (p CenterPrinter) Sprintfln(format string, a ...interface{}) string {
+	return p.Sprint(Sprintf(format, a...) + "\n")
+}
+
 // Print formats using the default formats for its operands and writes to standard output.
 // Spaces are added between operands when neither is a string.
 // It returns the number of bytes written and any write error encountered.
@@ -88,6 +94,15 @@ func (p CenterPrinter) Println(a ...interface{}) *TextPrinter {
 // It returns the number of bytes written and any write error encountered.
 func (p CenterPrinter) Printf(format string, a ...interface{}) *TextPrinter {
 	Print(p.Sprintf(format, a...))
+	tp := TextPrinter(p)
+	return &tp
+}
+
+// Printfln formats according to a format specifier and writes to standard output.
+// Spaces are always added between operands and a newline is appended.
+// It returns the number of bytes written and any write error encountered.
+func (p CenterPrinter) Printfln(format string, a ...interface{}) *TextPrinter {
+	Print(p.Sprintfln(format, a...))
 	tp := TextPrinter(p)
 	return &tp
 }

--- a/center_printer_test.go
+++ b/center_printer_test.go
@@ -30,6 +30,12 @@ func TestCenterPrinterPrintMethods(t *testing.T) {
 		})
 	})
 
+	t.Run("Printfln", func(t *testing.T) {
+		internal.TestPrintflnContains(t, func(w io.Writer, format string, a interface{}) {
+			p.Printfln(format, a)
+		})
+	})
+
 	t.Run("Println", func(t *testing.T) {
 		internal.TestPrintlnContains(t, func(w io.Writer, a interface{}) {
 			p.Println(a)
@@ -45,6 +51,12 @@ func TestCenterPrinterPrintMethods(t *testing.T) {
 	t.Run("Sprintf", func(t *testing.T) {
 		internal.TestSprintfContains(t, func(format string, a interface{}) string {
 			return p.Sprintf(format, a)
+		})
+	})
+
+	t.Run("Sprintfln", func(t *testing.T) {
+		internal.TestSprintflnContains(t, func(format string, a interface{}) string {
+			return p.Sprintfln(format, a)
 		})
 	})
 

--- a/color.go
+++ b/color.go
@@ -163,6 +163,13 @@ func (c Color) Sprintf(format string, a ...interface{}) string {
 	return c.Sprint(Sprintf(format, a...))
 }
 
+// Sprintfln formats according to a format specifier and returns the resulting string.
+// Spaces are always added between operands and a newline is appended.
+// Input will be colored with the parent Color.
+func (c Color) Sprintfln(format string, a ...interface{}) string {
+	return c.Sprint(Sprintf(format, a...) + "\n")
+}
+
 // Println formats using the default formats for its operands and writes to standard output.
 // Spaces are always added between operands and a newline is appended.
 // It returns the number of bytes written and any write error encountered.
@@ -190,6 +197,16 @@ func (c Color) Printf(format string, a ...interface{}) *TextPrinter {
 	Print(c.Sprintf(format, a...))
 	tc := TextPrinter(c)
 	return &tc
+}
+
+// Printfln formats according to a format specifier and writes to standard output.
+// Spaces are always added between operands and a newline is appended.
+// It returns the number of bytes written and any write error encountered.
+// Input will be colored with the parent Color.
+func (c Color) Printfln(format string, a ...interface{}) *TextPrinter {
+	Print(c.Sprintfln(format, a...))
+	tp := TextPrinter(c)
+	return &tp
 }
 
 // String converts the color to a string. eg "35".
@@ -244,6 +261,13 @@ func (s Style) Sprintf(format string, a ...interface{}) string {
 	return s.Sprint(Sprintf(format, a...))
 }
 
+// Sprintfln formats according to a format specifier and returns the resulting string.
+// Spaces are always added between operands and a newline is appended.
+// Input will be colored with the parent Style.
+func (s Style) Sprintfln(format string, a ...interface{}) string {
+	return s.Sprint(Sprintf(format, a...) + "\n")
+}
+
 // Print formats using the default formats for its operands and writes to standard output.
 // Spaces are added between operands when neither is a string.
 // It returns the number of bytes written and any write error encountered.
@@ -265,6 +289,14 @@ func (s Style) Println(a ...interface{}) {
 // Input will be colored with the parent Style.
 func (s Style) Printf(format string, a ...interface{}) {
 	Print(s.Sprintf(format, a...))
+}
+
+// Printfln formats according to a format specifier and writes to standard output.
+// Spaces are always added between operands and a newline is appended.
+// It returns the number of bytes written and any write error encountered.
+// Input will be colored with the parent Style.
+func (s Style) Printfln(format string, a ...interface{}) {
+	Print(s.Sprintfln(format, a...))
 }
 
 // Code convert to code string. returns like "32;45;3".

--- a/color_test.go
+++ b/color_test.go
@@ -23,6 +23,12 @@ func TestStylePrinterPrintMethods(t *testing.T) {
 		})
 	})
 
+	t.Run("Printfln", func(t *testing.T) {
+		internal.TestPrintflnContains(t, func(w io.Writer, format string, a interface{}) {
+			p.Printfln(format, a)
+		})
+	})
+
 	t.Run("Println", func(t *testing.T) {
 		internal.TestPrintlnContains(t, func(w io.Writer, a interface{}) {
 			p.Println(a)
@@ -38,6 +44,12 @@ func TestStylePrinterPrintMethods(t *testing.T) {
 	t.Run("Sprintf", func(t *testing.T) {
 		internal.TestSprintfContains(t, func(format string, a interface{}) string {
 			return p.Sprintf(format, a)
+		})
+	})
+
+	t.Run("Sprintfln", func(t *testing.T) {
+		internal.TestSprintflnContains(t, func(format string, a interface{}) string {
+			return p.Sprintfln(format, a)
 		})
 	})
 
@@ -70,6 +82,12 @@ func TestColorPrinterPrintMethods(t *testing.T) {
 		})
 	})
 
+	t.Run("Printfln", func(t *testing.T) {
+		internal.TestPrintflnContains(t, func(w io.Writer, format string, a interface{}) {
+			p.Printfln(format, a)
+		})
+	})
+
 	t.Run("Println", func(t *testing.T) {
 		internal.TestPrintlnContains(t, func(w io.Writer, a interface{}) {
 			p.Println(a)
@@ -85,6 +103,12 @@ func TestColorPrinterPrintMethods(t *testing.T) {
 	t.Run("Sprintf", func(t *testing.T) {
 		internal.TestSprintfContains(t, func(format string, a interface{}) string {
 			return p.Sprintf(format, a)
+		})
+	})
+
+	t.Run("Sprintfln", func(t *testing.T) {
+		internal.TestSprintflnContains(t, func(format string, a interface{}) string {
+			return p.Sprintfln(format, a)
 		})
 	})
 

--- a/docs/contributing/writing-documentation-template.md
+++ b/docs/contributing/writing-documentation-template.md
@@ -53,9 +53,11 @@
     |Sprint(a ...interface{})|Returns a string|
     |Sprintln(a ...interface{})|Returns a string with a new line at the end|
     |Sprintf(format string, a ...interface{})|Returns a string, formatted according to a format specifier|
+    |Sprintfln(format string, a ...interface{})|Returns a string, formatted according to a format specifier with a new line at the end|
     |Print(a ...interface{})|Prints to the terminal|
     |Println(a ...interface{})|Prints to the terminal with a new line at the end|
     |Printf(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier|
+    |Printfln(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier with a new line at the end|
     -->
     
     <!--

--- a/docs/docs/functions.md
+++ b/docs/docs/functions.md
@@ -13,6 +13,7 @@
 |-------------|-----------|
 |[Print](https://pkg.go.dev/github.com/pterm/pterm#Print)|Print formats using the default formats for its operands and writes to standard output. Spaces are added between operands when neither is a string. It returns the number of bytes written and any write error encountered.|
 |[Printf](https://pkg.go.dev/github.com/pterm/pterm#Printf)|Printf formats according to a format specifier and writes to standard output. It returns the number of bytes written and any write error encountered.|
+|[Printfln](https://pkg.go.dev/github.com/pterm/pterm#Printfln)|Printfln formats according to a format specifier and writes to standard output. It returns the number of bytes written and any write error encountered with a new line at the end.|
 |[Println](https://pkg.go.dev/github.com/pterm/pterm#Println)|Println formats using the default formats for its operands and writes to standard output. Spaces are always added between operands and a newline is appended. It returns the number of bytes written and any write error encountered.|
 |[Printo](https://pkg.go.dev/github.com/pterm/pterm#Printo)|Printo overrides the current line in a terminal. If the current line is empty, the text will be printed like with `pterm.Print`. Example: pterm.Printo("Hello, World") time.Sleep(time.Second) pterm.Printo("Hello, Earth!")|
 

--- a/docs/docs/printer/basictext.md
+++ b/docs/docs/printer/basictext.md
@@ -42,9 +42,11 @@ pterm.DefaultBasicText.Println("Hello, World!")
 |Sprint(a ...interface{})|Returns a string|
 |Sprintln(a ...interface{})|Returns a string with a new line at the end|
 |Sprintf(format string, a ...interface{})|Returns a string, formatted according to a format specifier|
+|Sprintfln(format string, a ...interface{})|Returns a string, formatted according to a format specifier with a new line at the end|
 |Print(a ...interface{})|Prints to the terminal|
 |Println(a ...interface{})|Prints to the terminal with a new line at the end|
 |Printf(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier|
+|Printfln(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier with a new line at the end|
 
 ## Related
 - [Override default printers](docs/customizing/override-default-printer.md)

--- a/docs/docs/printer/box.md
+++ b/docs/docs/printer/box.md
@@ -54,9 +54,11 @@ pterm.DefaultBox.Println("test")
 |Sprint(a ...interface{})|Returns a string|
 |Sprintln(a ...interface{})|Returns a string with a new line at the end|
 |Sprintf(format string, a ...interface{})|Returns a string, formatted according to a format specifier|
+|Sprintfln(format string, a ...interface{})|Returns a string, formatted according to a format specifier with a new line at the end|
 |Print(a ...interface{})|Prints to the terminal|
 |Println(a ...interface{})|Prints to the terminal with a new line at the end|
 |Printf(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier|
+|Printfln(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier with a new line at the end|
 
 ## Related
 - [Override default printers](docs/customizing/override-default-printer.md)

--- a/docs/docs/printer/center.md
+++ b/docs/docs/printer/center.md
@@ -41,10 +41,11 @@ pterm.DefaultCenter.Println("Hello,\nWorld!")
 |Sprint(a ...interface{})|Returns a string|
 |Sprintln(a ...interface{})|Returns a string with a new line at the end|
 |Sprintf(format string, a ...interface{})|Returns a string, formatted according to a format specifier|
+|Sprintfln(format string, a ...interface{})|Returns a string, formatted according to a format specifier with a new line at the end|
 |Print(a ...interface{})|Prints to the terminal|
 |Println(a ...interface{})|Prints to the terminal with a new line at the end|
 |Printf(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier|
-
+|Printfln(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier with a new line at the end|
 
 ## Related
 - [Override default printers](docs/customizing/override-default-printer.md)

--- a/docs/docs/printer/color.md
+++ b/docs/docs/printer/color.md
@@ -47,9 +47,11 @@ pterm.FgLightWhite.Println("FgLightWhite")
 |Sprint(a ...interface{})|Returns a string|
 |Sprintln(a ...interface{})|Returns a string with a new line at the end|
 |Sprintf(format string, a ...interface{})|Returns a string, formatted according to a format specifier|
+|Sprintfln(format string, a ...interface{})|Returns a string, formatted according to a format specifier with a new line at the end|
 |Print(a ...interface{})|Prints to the terminal|
 |Println(a ...interface{})|Prints to the terminal with a new line at the end|
 |Printf(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier|
+|Printfln(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier with a new line at the end|
 
 ## Related
 - [Override default printers](docs/customizing/override-default-printer.md)

--- a/docs/docs/printer/header.md
+++ b/docs/docs/printer/header.md
@@ -46,9 +46,11 @@ pterm.DefaultHeader.Println("Hello, World!")
 |Sprint(a ...interface{})|Returns a string|
 |Sprintln(a ...interface{})|Returns a string with a new line at the end|
 |Sprintf(format string, a ...interface{})|Returns a string, formatted according to a format specifier|
+|Sprintfln(format string, a ...interface{})|Returns a string, formatted according to a format specifier with a new line at the end|
 |Print(a ...interface{})|Prints to the terminal|
 |Println(a ...interface{})|Prints to the terminal with a new line at the end|
 |Printf(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier|
+|Printfln(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier with a new line at the end|
 
 ## Related
 - [Override default printers](docs/customizing/override-default-printer.md)

--- a/docs/docs/printer/paragraph.md
+++ b/docs/docs/printer/paragraph.md
@@ -42,9 +42,11 @@ pterm.DefaultParagraph.Println("Hello, World!")
 |Sprint(a ...interface{})|Returns a string|
 |Sprintln(a ...interface{})|Returns a string with a new line at the end|
 |Sprintf(format string, a ...interface{})|Returns a string, formatted according to a format specifier|
+|Sprintfln(format string, a ...interface{})|Returns a string, formatted according to a format specifier with a new line at the end|
 |Print(a ...interface{})|Prints to the terminal|
 |Println(a ...interface{})|Prints to the terminal with a new line at the end|
 |Printf(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier|
+|Printfln(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier with a new line at the end|
 
 ## Related
 - [Override default printers](docs/customizing/override-default-printer.md)

--- a/docs/docs/printer/prefix.md
+++ b/docs/docs/printer/prefix.md
@@ -71,9 +71,11 @@ pterm.Fatal.WithOptionName(option).WithOptionName2(option2).Println("Hello, Worl
 |Sprint(a ...interface{})|Returns a string|
 |Sprintln(a ...interface{})|Returns a string with a new line at the end|
 |Sprintf(format string, a ...interface{})|Returns a string, formatted according to a format specifier|
+|Sprintfln(format string, a ...interface{})|Returns a string, formatted according to a format specifier with a new line at the end|
 |Print(a ...interface{})|Prints to the terminal|
 |Println(a ...interface{})|Prints to the terminal with a new line at the end|
 |Printf(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier|
+|Printfln(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier with a new line at the end|
 
 ## Related
 

--- a/docs/docs/printer/rgb.md
+++ b/docs/docs/printer/rgb.md
@@ -36,9 +36,11 @@ pterm.NewRGB(178, 44, 199).Println("This text is printed with a custom RGB!")
 |Sprint(a ...interface{})|Returns a string|
 |Sprintln(a ...interface{})|Returns a string with a new line at the end|
 |Sprintf(format string, a ...interface{})|Returns a string, formatted according to a format specifier|
+|Sprintfln(format string, a ...interface{})|Returns a string, formatted according to a format specifier with a new line at the end|
 |Print(a ...interface{})|Prints to the terminal|
 |Println(a ...interface{})|Prints to the terminal with a new line at the end|
 |Printf(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier|
+|Printfln(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier with a new line at the end|
 
 ## Related
 - [Override default printers](docs/customizing/override-default-printer.md)

--- a/docs/docs/printer/section.md
+++ b/docs/docs/printer/section.md
@@ -46,9 +46,11 @@ pterm.DefaultSection.Println("Hello, World!")
 |Sprint(a ...interface{})|Returns a string|
 |Sprintln(a ...interface{})|Returns a string with a new line at the end|
 |Sprintf(format string, a ...interface{})|Returns a string, formatted according to a format specifier|
+|Sprintfln(format string, a ...interface{})|Returns a string, formatted according to a format specifier with a new line at the end|
 |Print(a ...interface{})|Prints to the terminal|
 |Println(a ...interface{})|Prints to the terminal with a new line at the end|
 |Printf(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier|
+|Printfln(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier with a new line at the end|
 
 ## Related
 - [Override default printers](docs/customizing/override-default-printer.md)

--- a/docs/docs/printer/style.md
+++ b/docs/docs/printer/style.md
@@ -36,9 +36,11 @@ pterm.NewStyle(pterm.FgLightCyan, pterm.BgGray, pterm.Bold).Println("Hello, Worl
 |Sprint(a ...interface{})|Returns a string|
 |Sprintln(a ...interface{})|Returns a string with a new line at the end|
 |Sprintf(format string, a ...interface{})|Returns a string, formatted according to a format specifier|
+|Sprintfln(format string, a ...interface{})|Returns a string, formatted according to a format specifier with a new line at the end|
 |Print(a ...interface{})|Prints to the terminal|
 |Println(a ...interface{})|Prints to the terminal with a new line at the end|
 |Printf(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier|
+|Printfln(format string, a ...interface{})|Prints to the terminal, formatted according to a format specifier with a new line at the end|
 
 ## Related
 - [Override default printers](docs/customizing/override-default-printer.md)

--- a/header_printer.go
+++ b/header_printer.go
@@ -91,6 +91,12 @@ func (p HeaderPrinter) Sprintf(format string, a ...interface{}) string {
 	return p.Sprint(Sprintf(format, a...))
 }
 
+// Sprintfln formats according to a format specifier and returns the resulting string.
+// Spaces are always added between operands and a newline is appended.
+func (p HeaderPrinter) Sprintfln(format string, a ...interface{}) string {
+	return p.Sprint(Sprintf(format, a...) + "\n")
+}
+
 // Print formats using the default formats for its operands and writes to standard output.
 // Spaces are added between operands when neither is a string.
 // It returns the number of bytes written and any write error encountered.
@@ -113,6 +119,15 @@ func (p *HeaderPrinter) Println(a ...interface{}) *TextPrinter {
 // It returns the number of bytes written and any write error encountered.
 func (p *HeaderPrinter) Printf(format string, a ...interface{}) *TextPrinter {
 	Print(p.Sprintf(format, a...))
+	tp := TextPrinter(p)
+	return &tp
+}
+
+// Printfln formats according to a format specifier and writes to standard output.
+// Spaces are always added between operands and a newline is appended.
+// It returns the number of bytes written and any write error encountered.
+func (p *HeaderPrinter) Printfln(format string, a ...interface{}) *TextPrinter {
+	Print(p.Sprintfln(format, a...))
 	tp := TextPrinter(p)
 	return &tp
 }

--- a/header_printer.go
+++ b/header_printer.go
@@ -94,7 +94,7 @@ func (p HeaderPrinter) Sprintf(format string, a ...interface{}) string {
 // Sprintfln formats according to a format specifier and returns the resulting string.
 // Spaces are always added between operands and a newline is appended.
 func (p HeaderPrinter) Sprintfln(format string, a ...interface{}) string {
-	return p.Sprint(Sprintf(format, a...) + "\n")
+	return p.Sprintf(format, a...) + "\n"
 }
 
 // Print formats using the default formats for its operands and writes to standard output.

--- a/header_printer_test.go
+++ b/header_printer_test.go
@@ -34,6 +34,12 @@ func TestHeaderPrinterPrintMethods(t *testing.T) {
 		})
 	})
 
+	t.Run("Printfln", func(t *testing.T) {
+		internal.TestPrintflnContains(t, func(w io.Writer, format string, a interface{}) {
+			p.Printfln(format, a)
+		})
+	})
+
 	t.Run("Println", func(t *testing.T) {
 		internal.TestPrintlnContains(t, func(w io.Writer, a interface{}) {
 			p.Println(a)
@@ -49,6 +55,12 @@ func TestHeaderPrinterPrintMethods(t *testing.T) {
 	t.Run("Sprintf", func(t *testing.T) {
 		internal.TestSprintfContains(t, func(format string, a interface{}) string {
 			return p.Sprintf(format, a)
+		})
+	})
+
+	t.Run("Sprintfln", func(t *testing.T) {
+		internal.TestSprintflnContains(t, func(format string, a interface{}) string {
+			return p.Sprintfln(format, a)
 		})
 	})
 

--- a/interface_text_printer.go
+++ b/interface_text_printer.go
@@ -13,6 +13,10 @@ type TextPrinter interface {
 	// Sprintf formats according to a format specifier and returns the resulting string.
 	Sprintf(format string, a ...interface{}) string
 
+	// Sprintfln formats according to a format specifier and returns the resulting string.
+	// Spaces are always added between operands and a newline is appended.
+	Sprintfln(format string, a ...interface{}) string
+
 	// Print formats using the default formats for its operands and writes to standard output.
 	// Spaces are added between operands when neither is a string.
 	// It returns the number of bytes written and any write error encountered.
@@ -26,4 +30,9 @@ type TextPrinter interface {
 	// Printf formats according to a format specifier and writes to standard output.
 	// It returns the number of bytes written and any write error encountered.
 	Printf(format string, a ...interface{}) *TextPrinter
+
+	// Printfln formats according to a format specifier and writes to standard output.
+	// Spaces are always added between operands and a newline is appended.
+	// It returns the number of bytes written and any write error encountered.
+	Printfln(format string, a ...interface{}) *TextPrinter
 }

--- a/internal/test_utils.go
+++ b/internal/test_utils.go
@@ -37,6 +37,15 @@ func TestPrintfContains(t *testing.T, logic func(w io.Writer, format string, a i
 	}
 }
 
+// TestPrintflnContains can be used to test Printfln methods.
+func TestPrintflnContains(t *testing.T, logic func(w io.Writer, format string, a interface{})) {
+	for _, printable := range printables {
+		t.Run(fmt.Sprint(printable), func(t *testing.T) {
+			TestPrintfContains(t, logic)
+		})
+	}
+}
+
 // TestPrintlnContains can be used to test Println methods.
 func TestPrintlnContains(t *testing.T, logic func(w io.Writer, a interface{})) {
 	for _, printable := range printables {
@@ -71,6 +80,15 @@ func TestSprintfContains(t *testing.T, logic func(format string, a interface{}) 
 	for _, printable := range printables {
 		t.Run(fmt.Sprint(printable), func(t *testing.T) {
 			assert.Contains(t, logic("Hello, %v!", printable), fmt.Sprintf("Hello, %v!", printable))
+		})
+	}
+}
+
+// TestSprintflnContains can be used to test Sprintfln methods.
+func TestSprintflnContains(t *testing.T, logic func(format string, a interface{}) string) {
+	for _, printable := range printables {
+		t.Run(fmt.Sprint(printable), func(t *testing.T) {
+			TestSprintfContains(t, logic)
 		})
 	}
 }

--- a/paragraph_printer.go
+++ b/paragraph_printer.go
@@ -55,6 +55,12 @@ func (p ParagraphPrinter) Sprintf(format string, a ...interface{}) string {
 	return p.Sprint(Sprintf(format, a...))
 }
 
+// Sprintfln formats according to a format specifier and returns the resulting string.
+// Spaces are always added between operands and a newline is appended.
+func (p ParagraphPrinter) Sprintfln(format string, a ...interface{}) string {
+	return p.Sprint(Sprintf(format, a...) + "\n")
+}
+
 // Print formats using the default formats for its operands and writes to standard output.
 // Spaces are added between operands when neither is a string.
 // It returns the number of bytes written and any write error encountered.
@@ -77,6 +83,15 @@ func (p *ParagraphPrinter) Println(a ...interface{}) *TextPrinter {
 // It returns the number of bytes written and any write error encountered.
 func (p *ParagraphPrinter) Printf(format string, a ...interface{}) *TextPrinter {
 	Print(p.Sprintf(format, a...))
+	tp := TextPrinter(p)
+	return &tp
+}
+
+// Printfln formats according to a format specifier and writes to standard output.
+// Spaces are always added between operands and a newline is appended.
+// It returns the number of bytes written and any write error encountered.
+func (p *ParagraphPrinter) Printfln(format string, a ...interface{}) *TextPrinter {
+	Print(p.Sprintfln(format, a...))
 	tp := TextPrinter(p)
 	return &tp
 }

--- a/paragraph_printer.go
+++ b/paragraph_printer.go
@@ -58,7 +58,7 @@ func (p ParagraphPrinter) Sprintf(format string, a ...interface{}) string {
 // Sprintfln formats according to a format specifier and returns the resulting string.
 // Spaces are always added between operands and a newline is appended.
 func (p ParagraphPrinter) Sprintfln(format string, a ...interface{}) string {
-	return p.Sprint(Sprintf(format, a...) + "\n")
+	return p.Sprintf(format, a...) + "\n"
 }
 
 // Print formats using the default formats for its operands and writes to standard output.

--- a/paragraph_printer_test.go
+++ b/paragraph_printer_test.go
@@ -37,6 +37,12 @@ func TestParagraphPrinterPrintMethods(t *testing.T) {
 		})
 	})
 
+	t.Run("Printfln", func(t *testing.T) {
+		internal.TestPrintflnContains(t, func(w io.Writer, format string, a interface{}) {
+			p.Printfln(format, a)
+		})
+	})
+
 	t.Run("Println", func(t *testing.T) {
 		internal.TestPrintlnContains(t, func(w io.Writer, a interface{}) {
 			p.Println(a)
@@ -52,6 +58,12 @@ func TestParagraphPrinterPrintMethods(t *testing.T) {
 	t.Run("Sprintf", func(t *testing.T) {
 		internal.TestSprintfContains(t, func(format string, a interface{}) string {
 			return p.Sprintf(format, a)
+		})
+	})
+
+	t.Run("Sprintfln", func(t *testing.T) {
+		internal.TestSprintflnContains(t, func(format string, a interface{}) string {
+			return p.Sprintfln(format, a)
 		})
 	})
 

--- a/prefix_printer.go
+++ b/prefix_printer.go
@@ -210,7 +210,7 @@ func (p PrefixPrinter) Sprintf(format string, a ...interface{}) string {
 // Sprintfln formats according to a format specifier and returns the resulting string.
 // Spaces are always added between operands and a newline is appended.
 func (p PrefixPrinter) Sprintfln(format string, a ...interface{}) string {
-	return p.Sprint(Sprintf(format, a...) + "\n")
+	return p.Sprintf(format, a...) + "\n"
 }
 
 // Print formats using the default formats for its operands and writes to standard output.

--- a/prefix_printer.go
+++ b/prefix_printer.go
@@ -207,6 +207,12 @@ func (p PrefixPrinter) Sprintf(format string, a ...interface{}) string {
 	return p.Sprint(Sprintf(format, a...))
 }
 
+// Sprintfln formats according to a format specifier and returns the resulting string.
+// Spaces are always added between operands and a newline is appended.
+func (p PrefixPrinter) Sprintfln(format string, a ...interface{}) string {
+	return p.Sprint(Sprintf(format, a...) + "\n")
+}
+
 // Print formats using the default formats for its operands and writes to standard output.
 // Spaces are added between operands when neither is a string.
 // It returns the number of bytes written and any write error encountered.
@@ -242,6 +248,15 @@ func (p *PrefixPrinter) Printf(format string, a ...interface{}) *TextPrinter {
 	}
 	Print(p.Sprintf(format, a...))
 	checkFatal(p)
+	return &tp
+}
+
+// Printfln formats according to a format specifier and writes to standard output.
+// Spaces are always added between operands and a newline is appended.
+// It returns the number of bytes written and any write error encountered.
+func (p *PrefixPrinter) Printfln(format string, a ...interface{}) *TextPrinter {
+	Print(p.Sprintfln(format, a...))
+	tp := TextPrinter(p)
 	return &tp
 }
 

--- a/prefix_printer_test.go
+++ b/prefix_printer_test.go
@@ -47,6 +47,12 @@ func TestPrefixPrinterPrintMethods(t *testing.T) {
 			})
 		})
 
+		t.Run("Printfln", func(t *testing.T) {
+			internal.TestPrintflnContains(t, func(w io.Writer, format string, a interface{}) {
+				p.Printfln(format, a)
+			})
+		})
+
 		t.Run("Println", func(t *testing.T) {
 			internal.TestPrintlnContains(t, func(w io.Writer, a interface{}) {
 				p.Println(a)
@@ -62,6 +68,12 @@ func TestPrefixPrinterPrintMethods(t *testing.T) {
 		t.Run("Sprintf", func(t *testing.T) {
 			internal.TestSprintfContains(t, func(format string, a interface{}) string {
 				return p.Sprintf(format, a)
+			})
+		})
+
+		t.Run("Sprintfln", func(t *testing.T) {
+			internal.TestSprintflnContains(t, func(format string, a interface{}) string {
+				return p.Sprintfln(format, a)
 			})
 		})
 

--- a/print.go
+++ b/print.go
@@ -24,6 +24,12 @@ func Sprintf(format string, a ...interface{}) string {
 	return color.Sprintf(format, a...)
 }
 
+// Sprintfln formats according to a format specifier and returns the resulting string.
+// Spaces are always added between operands and a newline is appended.
+func Sprintfln(format string, a ...interface{}) string {
+	return color.Sprint(Sprintf(format, a...) + "\n")
+}
+
 // Sprintln returns what Println would print to the terminal.
 func Sprintln(a ...interface{}) string {
 	str := fmt.Sprintln(a...)
@@ -72,6 +78,13 @@ func Println(a ...interface{}) {
 // It returns the number of bytes written and any write error encountered.
 func Printf(format string, a ...interface{}) {
 	Print(Sprintf(format, a...))
+}
+
+// Printfln formats according to a format specifier and writes to standard output.
+// Spaces are always added between operands and a newline is appended.
+// It returns the number of bytes written and any write error encountered.
+func Printfln(format string, a ...interface{}) {
+	Print(Sprintfln(format, a...))
 }
 
 // Fprint formats using the default formats for its operands and writes to w.

--- a/print.go
+++ b/print.go
@@ -27,7 +27,7 @@ func Sprintf(format string, a ...interface{}) string {
 // Sprintfln formats according to a format specifier and returns the resulting string.
 // Spaces are always added between operands and a newline is appended.
 func Sprintfln(format string, a ...interface{}) string {
-	return color.Sprint(Sprintf(format, a...) + "\n")
+	return color.Sprintf(format, a...) + "\n"
 }
 
 // Sprintln returns what Println would print to the terminal.

--- a/print_test.go
+++ b/print_test.go
@@ -23,6 +23,13 @@ func TestSprintf(t *testing.T) {
 	assert.Equal(t, "Hello, World!", Sprintf("Hello, %s!", "World"))
 }
 
+func TestSprintfln(t *testing.T) {
+	for _, randomString := range internal.RandomStrings {
+		assert.Equal(t, randomString+"\n", Sprintfln(randomString))
+	}
+	assert.Equal(t, "Hello, World!\n", Sprintfln("Hello, %s!", "World"))
+}
+
 func TestSprintln(t *testing.T) {
 	for _, randomString := range internal.RandomStrings {
 		assert.Equal(t, randomString+"\n", Sprintln(randomString))
@@ -108,6 +115,37 @@ func TestPrintf(t *testing.T) {
 		}
 		out := internal.CaptureStdout(func(w io.Writer) {
 			Printf("Hello, %s!", "World")
+		})
+		assert.Equal(t, "", out)
+		Output = true
+	})
+}
+
+func TestPrintfln(t *testing.T) {
+	t.Run("enabled output", func(t *testing.T) {
+		Output = true
+		for _, randomString := range internal.RandomStrings {
+			out := internal.CaptureStdout(func(w io.Writer) {
+				Printfln(randomString)
+			})
+			assert.Equal(t, randomString+"\n", out)
+		}
+		out := internal.CaptureStdout(func(w io.Writer) {
+			Printfln("Hello, %s!", "World")
+		})
+		assert.Equal(t, "Hello, World!\n", out)
+	})
+
+	t.Run("disabled output", func(t *testing.T) {
+		Output = false
+		for _, randomString := range internal.RandomStrings {
+			out := internal.CaptureStdout(func(w io.Writer) {
+				Printfln(randomString)
+			})
+			assert.Equal(t, "", out)
+		}
+		out := internal.CaptureStdout(func(w io.Writer) {
+			Printfln("Hello, %s!", "World")
 		})
 		assert.Equal(t, "", out)
 		Output = true

--- a/rgb.go
+++ b/rgb.go
@@ -101,6 +101,12 @@ func (p RGB) Sprintf(format string, a ...interface{}) string {
 	return p.Sprint(Sprintf(format, a...))
 }
 
+// Sprintfln formats according to a format specifier and returns the resulting string.
+// Spaces are always added between operands and a newline is appended.
+func (p RGB) Sprintfln(format string, a ...interface{}) string {
+	return p.Sprint(Sprintf(format, a...) + "\n")
+}
+
 // Print formats using the default formats for its operands and writes to standard output.
 // Spaces are added between operands when neither is a string.
 // It returns the number of bytes written and any write error encountered.
@@ -123,6 +129,15 @@ func (p RGB) Println(a ...interface{}) *TextPrinter {
 // It returns the number of bytes written and any write error encountered.
 func (p RGB) Printf(format string, a ...interface{}) *TextPrinter {
 	Print(p.Sprintf(format, a...))
+	tp := TextPrinter(p)
+	return &tp
+}
+
+// Printfln formats according to a format specifier and writes to standard output.
+// Spaces are always added between operands and a newline is appended.
+// It returns the number of bytes written and any write error encountered.
+func (p RGB) Printfln(format string, a ...interface{}) *TextPrinter {
+	Print(p.Sprintfln(format, a...))
 	tp := TextPrinter(p)
 	return &tp
 }

--- a/rgb.go
+++ b/rgb.go
@@ -104,7 +104,7 @@ func (p RGB) Sprintf(format string, a ...interface{}) string {
 // Sprintfln formats according to a format specifier and returns the resulting string.
 // Spaces are always added between operands and a newline is appended.
 func (p RGB) Sprintfln(format string, a ...interface{}) string {
-	return p.Sprint(Sprintf(format, a...) + "\n")
+	return p.Sprintf(format, a...) + "\n"
 }
 
 // Print formats using the default formats for its operands and writes to standard output.

--- a/rgb_test.go
+++ b/rgb_test.go
@@ -176,6 +176,19 @@ func TestRGB_Printf(t *testing.T) {
 	}
 }
 
+func TestRGB_Printfln(t *testing.T) {
+	RGBs := []RGB{{0, 0, 0}, {127, 127, 127}, {255, 255, 255}}
+
+	for _, rgb := range RGBs {
+		t.Run(Sprintfln("%v %v %v", rgb.R, rgb.G, rgb.B), func(t *testing.T) {
+			internal.TestPrintflnContains(t, func(w io.Writer, format string, a interface{}) {
+				p := rgb.Printfln(format, a)
+				assert.NotNil(t, p)
+			})
+		})
+	}
+}
+
 func TestRGB_Println(t *testing.T) {
 	RGBs := []RGB{{0, 0, 0}, {127, 127, 127}, {255, 255, 255}}
 
@@ -208,6 +221,18 @@ func TestRGB_Sprintf(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			internal.TestSprintfContains(t, func(format string, a interface{}) string {
 				return rgb.Sprintf(format, a)
+			})
+		})
+	}
+}
+
+func TestRGB_Sprintfln(t *testing.T) {
+	RGBs := []RGB{{0, 0, 0}, {127, 127, 127}, {255, 255, 255}}
+
+	for _, rgb := range RGBs {
+		t.Run("", func(t *testing.T) {
+			internal.TestSprintflnContains(t, func(format string, a interface{}) string {
+				return rgb.Sprintfln(format, a)
 			})
 		})
 	}

--- a/section_printer.go
+++ b/section_printer.go
@@ -92,6 +92,12 @@ func (p SectionPrinter) Sprintf(format string, a ...interface{}) string {
 	return p.Sprint(Sprintf(format, a...))
 }
 
+// Sprintfln formats according to a format specifier and returns the resulting string.
+// Spaces are always added between operands and a newline is appended.
+func (p SectionPrinter) Sprintfln(format string, a ...interface{}) string {
+	return p.Sprint(Sprintf(format, a...) + "\n")
+}
+
 // Print formats using the default formats for its operands and writes to standard output.
 // Spaces are added between operands when neither is a string.
 // It returns the number of bytes written and any write error encountered.
@@ -114,6 +120,15 @@ func (p *SectionPrinter) Println(a ...interface{}) *TextPrinter {
 // It returns the number of bytes written and any write error encountered.
 func (p *SectionPrinter) Printf(format string, a ...interface{}) *TextPrinter {
 	Print(p.Sprintf(format, a...))
+	tp := TextPrinter(p)
+	return &tp
+}
+
+// Printfln formats according to a format specifier and writes to standard output.
+// Spaces are always added between operands and a newline is appended.
+// It returns the number of bytes written and any write error encountered.
+func (p *SectionPrinter) Printfln(format string, a ...interface{}) *TextPrinter {
+	Print(p.Sprintfln(format, a...))
 	tp := TextPrinter(p)
 	return &tp
 }

--- a/section_printer.go
+++ b/section_printer.go
@@ -95,7 +95,7 @@ func (p SectionPrinter) Sprintf(format string, a ...interface{}) string {
 // Sprintfln formats according to a format specifier and returns the resulting string.
 // Spaces are always added between operands and a newline is appended.
 func (p SectionPrinter) Sprintfln(format string, a ...interface{}) string {
-	return p.Sprint(Sprintf(format, a...) + "\n")
+	return p.Sprintf(format, a...) + "\n"
 }
 
 // Print formats using the default formats for its operands and writes to standard output.

--- a/section_printer_test.go
+++ b/section_printer_test.go
@@ -27,6 +27,12 @@ func TestSectionPrinterPrintMethods(t *testing.T) {
 		})
 	})
 
+	t.Run("Printfln", func(t *testing.T) {
+		internal.TestPrintflnContains(t, func(w io.Writer, format string, a interface{}) {
+			p.Printfln(format, a)
+		})
+	})
+
 	t.Run("Println", func(t *testing.T) {
 		internal.TestPrintlnContains(t, func(w io.Writer, a interface{}) {
 			p.Println(a)
@@ -42,6 +48,12 @@ func TestSectionPrinterPrintMethods(t *testing.T) {
 	t.Run("Sprintf", func(t *testing.T) {
 		internal.TestSprintfContains(t, func(format string, a interface{}) string {
 			return p.Sprintf(format, a)
+		})
+	})
+
+	t.Run("Sprintfln", func(t *testing.T) {
+		internal.TestSprintflnContains(t, func(format string, a interface{}) string {
+			return p.Sprintfln(format, a)
 		})
 	})
 


### PR DESCRIPTION
### Description
Added `Sprintfln` and `Printfln` functions for all printers.

### Scope
> What is affected by this pull request?

- [ ] Bug Fix
- [x] New Feature
- [x] Documentation
- [ ] Other

### Related Issue
Fixes #191 


### To-Do Checklist
- [x] I tested my changes
- [x] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods
