### PR TITLE
Add `PrintIfError` to `PrefixPrinter`

### DIFF
--- a/docs/docs/printer/prefix.md
+++ b/docs/docs/printer/prefix.md
@@ -27,6 +27,7 @@ pterm.Fatal.Println("Hello, World!") // Print Fatal.
 |Function|Description|
 |--------|-----------|
 |[FormattedPrefix](https://pkg.go.dev/github.com/pterm/pterm#PrefixPrinter.GetFormattedPrefix)|Returns the Prefix as a styled text string.|
+|[PrintIfError](https://pkg.go.dev/github.com/pterm/pterm#PrefixPrinter.PrintIfError)|Only prints if the given error is not nil.|
 
 ### Options
 

--- a/prefix_printer.go
+++ b/prefix_printer.go
@@ -197,6 +197,16 @@ func (p *PrefixPrinter) Sprint(a ...interface{}) string {
 	return Sprint(ret)
 }
 
+// PrintIfError prints if the given error is not nil.
+// This can be used for simple error checking.
+//
+// Note: Use WithFatal(true) or Fatal to panic after printing.
+func (p PrefixPrinter) PrintIfError(err error) {
+	if err != nil {
+		p.Println(p.Sprint(Sprint(err)))
+	}
+}
+
 // Sprintln formats using the default formats for its operands and returns the resulting string.
 // Spaces are always added between operands and a newline is appended.
 func (p PrefixPrinter) Sprintln(a ...interface{}) string {

--- a/prefix_printer_test.go
+++ b/prefix_printer_test.go
@@ -1,6 +1,7 @@
 package pterm
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -82,6 +83,20 @@ func TestPrefixPrinterPrintMethods(t *testing.T) {
 			testSprintlnContains(t, func(a interface{}) string {
 				return p.Sprintln(a)
 			})
+		})
+
+		t.Run("PrintIfError", func(t *testing.T) {
+			result := captureStdout(func(w io.Writer) {
+				p.PrintIfError(errors.New("hello world"))
+			})
+			assert.Contains(t, result, "hello world")
+		})
+
+		t.Run("PrintIfError_WithoutError", func(t *testing.T) {
+			result := captureStdout(func(w io.Writer) {
+				p.PrintIfError(nil)
+			})
+			assert.Empty(t, result)
 		})
 	}
 }


### PR DESCRIPTION
### Description
Adds the function `PrintIfError` to `PrefixPrinter`, which only prints if the given error is not nil

### Scope
> What is affected by this pull request?

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Other

### To-Do Checklist
- [x] I tested my changes
- [x] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods
