### PR TITLE
fix: fix `pterm.Fatal.Printfln` not panicking

### DIFF
--- a/prefix_printer.go
+++ b/prefix_printer.go
@@ -280,6 +280,7 @@ func (p *PrefixPrinter) Printf(format string, a ...interface{}) *TextPrinter {
 func (p *PrefixPrinter) Printfln(format string, a ...interface{}) *TextPrinter {
 	Print(p.Sprintfln(format, a...))
 	tp := TextPrinter(p)
+	checkFatal(p)
 	return &tp
 }
 

--- a/prefix_printer.go
+++ b/prefix_printer.go
@@ -233,6 +233,9 @@ func (p PrefixPrinter) Sprintf(format string, a ...interface{}) string {
 // Sprintfln formats according to a format specifier and returns the resulting string.
 // Spaces are always added between operands and a newline is appended.
 func (p PrefixPrinter) Sprintfln(format string, a ...interface{}) string {
+	if p.Debugger && !PrintDebugMessages {
+		return ""
+	}
 	return p.Sprintf(format, a...) + "\n"
 }
 
@@ -278,8 +281,11 @@ func (p *PrefixPrinter) Printf(format string, a ...interface{}) *TextPrinter {
 // Spaces are always added between operands and a newline is appended.
 // It returns the number of bytes written and any write error encountered.
 func (p *PrefixPrinter) Printfln(format string, a ...interface{}) *TextPrinter {
-	Print(p.Sprintfln(format, a...))
 	tp := TextPrinter(p)
+	if p.Debugger && !PrintDebugMessages {
+		return &tp
+	}
+	Print(p.Sprintfln(format, a...))
 	checkFatal(p)
 	return &tp
 }

--- a/prefix_printer_test.go
+++ b/prefix_printer_test.go
@@ -321,6 +321,18 @@ func TestPrefixPrinter_PrintfWithoutDebugger(t *testing.T) {
 	}
 }
 
+func TestPrefixPrinter_PrintflnWithoutDebugger(t *testing.T) {
+	for _, p := range prefixPrinters {
+		t.Run("", func(t *testing.T) {
+			p2 := p.WithDebugger()
+			DisableDebugMessages()
+			testDoesNotOutput(t, func(w io.Writer) {
+				p2.Printfln("Hello, World!")
+			})
+		})
+	}
+}
+
 func TestPrefixPrinter_SprintWithoutDebugger(t *testing.T) {
 	for _, p := range prefixPrinters {
 		t.Run("", func(t *testing.T) {
@@ -351,6 +363,18 @@ func TestPrefixPrinter_SprintfWithoutDebugger(t *testing.T) {
 			DisableDebugMessages()
 			testEmpty(t, func(a interface{}) string {
 				return p2.Sprintf("Hello, %s!", a)
+			})
+		})
+	}
+}
+
+func TestPrefixPrinter_SprintflnWithoutDebugger(t *testing.T) {
+	for _, p := range prefixPrinters {
+		t.Run("", func(t *testing.T) {
+			p2 := p.WithDebugger()
+			DisableDebugMessages()
+			testEmpty(t, func(a interface{}) string {
+				return p2.Sprintfln("Hello, %s!", a)
 			})
 		})
 	}


### PR DESCRIPTION
### Description
Fix `pterm.Fatal.Printfln` not panicking because `checkFatal` was not checked.

### Scope
> What is affected by this pull request?

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

### Related Issue
Fixes #196 


### To-Do Checklist
- [x] I tested my changes
- [ ] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [ ] I have added tests for my newly created methods
