### PR TITLE
refactor(prefix): `pterm.Error` default no line number shown

### DIFF
--- a/prefix_printer.go
+++ b/prefix_printer.go
@@ -48,7 +48,6 @@ var (
 			Style: &ThemeDefault.ErrorPrefixStyle,
 			Text:  " ERROR ",
 		},
-		ShowLineNumber: true,
 	}
 
 	// Fatal returns a PrefixPrinter, which can be used to print text with an "fatal" Prefix.

--- a/prefix_printer_test.go
+++ b/prefix_printer_test.go
@@ -35,6 +35,13 @@ func TestPrefixPrinterPrintMethods(t *testing.T) {
 			})
 		})
 
+		t.Run("PrintWithShowLineNumber", func(t *testing.T) {
+			testPrintContains(t, func(w io.Writer, a interface{}) {
+				p2 := p.WithShowLineNumber()
+				p2.Print(a)
+			})
+		})
+
 		t.Run("PrintWithMultipleLines", func(t *testing.T) {
 			p2 := p.WithScope(Scope{
 				Text:  "test",


### PR DESCRIPTION
### Description
Change `pterm.Error` default to no line number shown.

### Scope
> What is affected by this pull request?

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Other

### Related Issue
Fixes #


### To-Do Checklist
- [x] I tested my changes
- [ ] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods
