### PR TITLE
feat(table): add `Boxed` option

### DIFF
--- a/table_printer.go
+++ b/table_printer.go
@@ -27,6 +27,7 @@ type TablePrinter struct {
 	Separator      string
 	SeparatorStyle *Style
 	Data           TableData
+	Boxed          bool
 }
 
 // WithStyle returns a new TablePrinter with a specific Style.
@@ -70,6 +71,12 @@ func (p TablePrinter) WithCSVReader(reader *csv.Reader) *TablePrinter {
 	if records, err := reader.ReadAll(); err == nil {
 		p.Data = records
 	}
+	return &p
+}
+
+// WithBoxed returns a new TablePrinter with a box around the table.
+func (p TablePrinter) WithBoxed(b ...bool) *TablePrinter {
+	p.Boxed = internal.WithBoolean(b)
 	return &p
 }
 
@@ -117,6 +124,10 @@ func (p TablePrinter) Srender() (string, error) {
 	}
 
 	ret = strings.TrimSuffix(ret, "\n")
+
+	if p.Boxed {
+		ret = DefaultBox.Sprint(ret)
+	}
 
 	return ret, nil
 }

--- a/table_printer_test.go
+++ b/table_printer_test.go
@@ -30,6 +30,13 @@ func TestTablePrinter_WithCSVReader(t *testing.T) {
 	p2.Srender()
 }
 
+func TestTablePrinter_WithBoxed(t *testing.T) {
+	_, err := DefaultTable.WithBoxed().Srender()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestTablePrinter_WithData(t *testing.T) {
 	proxyToDevNull()
 	d := TableData{


### PR DESCRIPTION
### Description
Add an option to the `TablePrinter`, which adds a box around it.

### Scope
> What is affected by this pull request?

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Other

### Related Issue
Fixes #225 


### To-Do Checklist
- [x] I tested my changes
- [ ] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods
