### PR TITLE
fix(spinner): Override previous text in `UpdateText`

### DIFF
--- a/spinner_printer.go
+++ b/spinner_printer.go
@@ -77,14 +77,14 @@ func (s SpinnerPrinter) WithRemoveWhenDone(b ...bool) *SpinnerPrinter {
 // UpdateText updates the message of the active SpinnerPrinter.
 // Can be used live.
 func (s *SpinnerPrinter) UpdateText(text string) {
+	s.Text = text
 	if !RawOutput {
 		clearLine()
 		Printo(s.Style.Sprint(s.currentSequence) + " " + s.MessageStyle.Sprint(s.Text))
 	}
 	if RawOutput {
-		Println(text)
+		Println(s.Text)
 	}
-	s.Text = text
 }
 
 // Start the SpinnerPrinter.

--- a/spinner_printer_test.go
+++ b/spinner_printer_test.go
@@ -49,11 +49,23 @@ func TestSpinnerPrinter_Success(t *testing.T) {
 }
 
 func TestSpinnerPrinter_UpdateText(t *testing.T) {
-	p := DefaultSpinner
-	p.Start()
-	p.UpdateText("test")
+	t.Run("Simple", func(t *testing.T) {
+		p := DefaultSpinner
+		p.Start()
+		p.UpdateText("test")
 
-	assert.Equal(t, "test", p.Text)
+		assert.Equal(t, "test", p.Text)
+	})
+
+	t.Run("Override", func(t *testing.T) {
+		out := captureStdout(func(io.Writer) {
+			// Set a really long delay to make sure text doesn't get updated before function returns.
+			p := DefaultSpinner.WithDelay(1*time.Hour)
+			p.Start("An initial long message")
+			p.UpdateText("A short message")
+		})
+		assert.Contains(t, out, "A short message")
+	})
 }
 
 func TestSpinnerPrinter_UpdateTextRawOutput(t *testing.T) {


### PR DESCRIPTION
### Description
Updated `p.Text` before the call to `Printo` so that the new text gets printed instead of what was previously stored.

### Scope
`SpinnerPrinter`.

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

### Related Issue
Fixes #227

### To-Do Checklist
- [x] I tested my changes
- [x] I have commented every method that I created/changed
- [x] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods