### PR TITLE
fix(bar chart): fix panic when rendering empty horizontal bar chart

### DIFF
--- a/barchart.go
+++ b/barchart.go
@@ -126,7 +126,11 @@ func (p BarChartPrinter) Srender() (string, error) {
 		panels := Panels{[]Panel{{}, {}}}
 		for _, bar := range p.Bars {
 			panels[0][0].Data += "\n" + bar.Label
-			panels[0][1].Data += "\n" + bar.Style.Sprint(strings.Repeat(p.HorizontalBarCharacter, internal.MapRangeToRange(0, float32(maxBarValue), 0, float32(p.Width), float32(bar.Value))))
+			repeatCount := internal.MapRangeToRange(0, float32(maxBarValue), 0, float32(p.Width), float32(bar.Value))
+			if repeatCount < 0 {
+				repeatCount = 0
+			}
+			panels[0][1].Data += "\n" + bar.Style.Sprint(strings.Repeat(p.HorizontalBarCharacter, repeatCount))
 			if p.ShowValue {
 				panels[0][1].Data += " " + strconv.Itoa(bar.Value)
 			}

--- a/barchart_test.go
+++ b/barchart_test.go
@@ -121,6 +121,21 @@ func TestBarChartPrinter_RenderNegativeBarValues(t *testing.T) {
 	}).Render()
 }
 
+func TestBarChartPrinter_RenderZeroBarValuesHorizontal(t *testing.T) {
+	DefaultBarChart.WithShowValue().WithHorizontal().WithBars(Bars{
+		Bar{
+			Label: "Test",
+			Value: 0,
+			Style: NewStyle(FgRed, BgBlue, Bold),
+		},
+		Bar{
+			Label: "Test",
+			Value: 0,
+			Style: NewStyle(FgRed, BgBlue, Bold),
+		},
+	}).Render()
+}
+
 func TestBarChartPrinter_RenderZeroBarValues(t *testing.T) {
 	DefaultBarChart.WithShowValue().WithBars(Bars{
 		Bar{


### PR DESCRIPTION
Fixes #233

### Description
The second argument to `strings.Repeat()` cannot be negative, and this causes a panic when the bar chart is rendered horizontally with zero values. This PR ensures that the argument to `strings.Repeat()` can no longer be zero this preventing the panic.

### Scope
> What is affected by this pull request?

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

### Related Issue
Fixes #233 


### To-Do Checklist
- [x] I tested my changes
- [x] I have commented every method that I created/changed
- [x] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods
