### PR TITLE
docs(area): added `Clear` method to docs

### DIFF
--- a/docs/docs/printer/area.md
+++ b/docs/docs/printer/area.md
@@ -25,6 +25,7 @@ area.Stop()
 |--------|-----------|
 |[Update](https://pkg.go.dev/github.com/pterm/pterm#AreaPrinter.Update)|Update overwrites the content of the AreaPrinter.|
 |[GetContent](https://pkg.go.dev/github.com/pterm/pterm#AreaPrinter.GetContent)|GetContent returns the current area content.|
+|[Clear](https://pkg.go.dev/github.com/pterm/pterm#AreaPrinter.Clear)|Clear function clears the content of the area.|
 
 ### Options
 


### PR DESCRIPTION
### Description

Updated [area.md](https://github.com/pterm/pterm/blob/master/docs/docs/printer/area.md) by adding AreaPrinter.Clear().

### Scope

Updated the documentation of [area.md](https://github.com/pterm/pterm/blob/master/docs/docs/printer/area.md).

- [x] Documentation

### Related Issue

Fixed Issue #266.
