### PR TITLE
fix: progressbar method name

### DIFF
--- a/docs/docs/printer/progressbar.md
+++ b/docs/docs/printer/progressbar.md
@@ -17,7 +17,7 @@ Replace all of the following strings with the current printer.
 ```go
 progressbar := pterm.DefaultProgressbar.WithTotal(totalSteps).Start()
 // Logic here
-progressbar.Increase()
+progressbar.Increment()
 // More logic
 ```
 


### PR DESCRIPTION
### Description

The documentation was still using `Increase` instead of `Increment` for progress bars.

### Scope
> What is affected by this pull request?

- [ ] Bug Fix
- [ ] New Feature
- [X] Documentation
- [ ] Other

### To-Do Checklist
- [x] I tested my changes
- [x] I have commented every method that I created/changed
- [x] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods
