### PR TITLE
refactor: fixes the 'bitSize' argument is invalid, must be either 32 or 64 linter error

### DIFF
--- a/ci/main.go
+++ b/ci/main.go
@@ -149,7 +149,7 @@ func processFile(f os.FileInfo) {
 	animationDataLines := getLinesFromFile(animationDataPath)
 	animationDataLastLine := animationDataLines[len(animationDataLines)-1]
 	re := regexp.MustCompile(`\[\d[^,]*`).FindAllString(animationDataLastLine, 1)[0]
-	lastTime, _ := strconv.ParseFloat(strings.ReplaceAll(re, "[", ""), 10)
+	lastTime, _ := strconv.ParseFloat(strings.ReplaceAll(re, "[", ""), 64)
 	sleepString := `[` + strconv.FormatFloat(lastTime+5, 'f', 6, 64) + `, "o", "\nRestarting animation...\n"]`
 	animationDataFile, err := os.OpenFile(animationDataPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {


### PR DESCRIPTION
### Description
Describe your work here.

### Scope
> What is affected by this pull request?

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Other

### Related Issue
Fixes #
'bitSize' argument is invalid, must be either 32 or 64

### To-Do Checklist
- [ ] I tested my changes
- [ ] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [ ] I have added tests for my newly created methods
