### PR TITLE
feat: group tables before rendering

### DIFF
--- a/interface_grouper.go
+++ b/interface_grouper.go
@@ -1,0 +1,12 @@
+package pterm
+
+type Grouper interface {
+	// Append the XXX to the Grouper instance
+	Append(items ...interface{}) Grouper
+
+	// Render the XXX to the terminal.
+	Render() error
+
+	// Srender returns the rendered string of XXX.
+	Srender() (string, error)
+}

--- a/table_group_printer.go
+++ b/table_group_printer.go
@@ -1,0 +1,209 @@
+package pterm
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/pterm/pterm/internal"
+)
+
+// DefaultGroupTable contains standards, which can be used to print a TablePrinter.
+var DefaultGroupTable = TableGroup{
+	Style:           &ThemeDefault.TableStyle,
+	HasHeader:       true,
+	HeaderStyle:     &ThemeDefault.TableHeaderStyle,
+	Separator:       " | ",
+	SeparatorStyle:  &ThemeDefault.TableSeparatorStyle,
+	HSeparator:      "-",
+	HSeparatorStyle: &ThemeDefault.TableSeparatorStyle,
+}
+
+type TableGroup struct {
+	Style           *Style
+	HasHeader       bool
+	HeaderStyle     *Style
+	Separator       string
+	SeparatorStyle  *Style
+	Boxed           bool
+	HSeparator      string
+	HSeparatorStyle *Style
+	Share           bool
+	ColumnLength    map[int]int
+	Columns         int
+	Tables          []*TablePrinter
+}
+
+// WithShare returns a new TableGroup that all tables within share same values.
+func (t *TableGroup) WithShare(b ...bool) *TableGroup {
+	t.Share = internal.WithBoolean(b)
+	return t
+}
+
+// WithStyle returns a new TableGroup with a specific Style.
+func (t *TableGroup) WithStyle(style *Style) *TableGroup {
+	t.Style = style
+	return t
+}
+
+// WithHasHeader returns a new TablePrinter, where the first line is marked as a header.
+func (t *TableGroup) WithHasHeader(b ...bool) *TableGroup {
+	t.HasHeader = internal.WithBoolean(b)
+	return t
+}
+
+// WithHeaderStyle returns a new TableGroup with a specific HeaderStyle.
+func (t *TableGroup) WithHeaderStyle(style *Style) *TableGroup {
+	t.HeaderStyle = style
+	return t
+}
+
+// WithSeparator returns a new TableGroup with a specific separator.
+func (t *TableGroup) WithSeparator(separator string) *TableGroup {
+	t.Separator = separator
+	return t
+}
+
+// WithSeparatorStyle returns a new TableGroup with a specific SeparatorStyle.
+func (t *TableGroup) WithSeparatorStyle(style *Style) *TableGroup {
+	t.SeparatorStyle = style
+	return t
+}
+
+// WithHorizontalSeparator returns a new TableGroup with a specific horizontal separator.
+func (t *TableGroup) WithHorizontalSeparator(separator string) *TableGroup {
+	if utf8.RuneCountInString(separator) != 1 {
+		t.HSeparator = DefaultGroupTable.HSeparator
+
+		return t
+	}
+
+	t.HSeparator = separator
+
+	return t
+}
+
+// WithHorizontalSeparatorStyle returns a new TableGroup with a specific HorizontalSeparatorStyle.
+func (t *TableGroup) WithHorizontalSeparatorStyle(style *Style) *TableGroup {
+	t.HSeparatorStyle = style
+	return t
+}
+
+// WithBoxed returns a new TableGroup with a box around the table.
+func (t *TableGroup) WithBoxed(b ...bool) *TableGroup {
+	t.Boxed = internal.WithBoolean(b)
+	return t
+}
+
+// Append appends the table to the TableGroup.
+func (t *TableGroup) Append(items ...interface{}) Grouper {
+	if t.ColumnLength == nil {
+		t.ColumnLength = make(map[int]int)
+	}
+
+	for _, item := range items {
+		if table, ok := item.(*TablePrinter); ok {
+			if len(table.Data[0]) > t.Columns {
+				t.Columns = len(table.Data[0])
+			}
+
+			for _, row := range table.Data {
+				for ci, column := range row {
+					columnLength := utf8.RuneCountInString(RemoveColorFromString(column))
+					if columnLength > t.ColumnLength[ci] {
+						t.ColumnLength[ci] = columnLength
+					}
+				}
+			}
+
+			t.Tables = append(t.Tables, table)
+		}
+	}
+
+	g := Grouper(t)
+	return g
+}
+
+// Srender renders the TableGroup as a string.
+func (t *TableGroup) Srender() (string, error) {
+	var ret string
+
+	for ti, table := range t.Tables {
+		if t.Share {
+			table.Style = t.Style
+			table.HasHeader = t.HasHeader
+			table.HeaderStyle = t.HeaderStyle
+			table.Separator = t.Separator
+			table.SeparatorStyle = t.SeparatorStyle
+		}
+
+		if table.Style == nil {
+			table.Style = NewStyle()
+		}
+		if table.SeparatorStyle == nil {
+			table.SeparatorStyle = NewStyle()
+		}
+		if table.HeaderStyle == nil {
+			table.HeaderStyle = NewStyle()
+		}
+
+		for ri, row := range table.Data {
+			for i := 0; i < t.Columns; i++ {
+				columnString := ""
+				if i < len(row) {
+					columnLength := utf8.RuneCountInString(RemoveColorFromString(row[i]))
+					columnString = row[i] + strings.Repeat(" ", t.ColumnLength[i]-columnLength)
+				} else {
+					columnString = strings.Repeat(" ", t.ColumnLength[i])
+				}
+
+				if i != 0 {
+					ret += table.Style.Sprint(table.SeparatorStyle.Sprint(table.Separator))
+				}
+
+				if table.HasHeader && ri == 0 {
+					ret += table.Style.Sprint(table.HeaderStyle.Sprint(columnString))
+				} else {
+					ret += table.Style.Sprint(columnString)
+				}
+			}
+
+			ret += "\n"
+		}
+
+		if t.HSeparator != "" && ti != len(t.Tables)-1 {
+			ret += t.horizontalSeparator()
+
+			ret += "\n"
+		}
+	}
+
+	ret = strings.TrimSuffix(ret, "\n")
+
+	if t.Boxed {
+		ret = DefaultBox.Sprint(ret)
+	}
+
+	return ret, nil
+}
+
+// Render prints the TableGroup to the terminal.
+func (t *TableGroup) Render() error {
+	s, _ := t.Srender()
+	Println(s)
+
+	return nil
+}
+
+func (t *TableGroup) horizontalSeparator() string {
+	width := 0
+
+	for i, l := range t.ColumnLength {
+		width += l
+
+		if i != len(t.ColumnLength) && i != 0 {
+			width += utf8.RuneCountInString(t.Separator)
+		}
+	}
+
+	return t.Style.Sprint(t.HSeparatorStyle.Sprint(strings.Repeat(t.HSeparator, width)))
+}

--- a/table_group_printer_test.go
+++ b/table_group_printer_test.go
@@ -1,0 +1,158 @@
+package pterm_test
+
+import (
+	"testing"
+
+	"github.com/MarvinJWendt/testza"
+
+	"github.com/pterm/pterm"
+)
+
+func TestTableGroupGroupPrinter_NilPrint(t *testing.T) {
+	p := pterm.TableGroup{}
+	_ = p.Render()
+}
+
+func TestTableGroupPrinter_Append(t *testing.T) {
+	// pterm.proxyToDevNull()
+
+	d3 := pterm.TableData{
+		{"Firstname", "Lastname", "Email"},
+		{"Paul", "Dean", "nisi.dictum.augue@velitAliquam.co.uk"},
+		{"Callie", "Mckay", "egestas.nunc.sed@est.com"},
+		{"Libby", "Camacho", "aliquet.lobortis@semper.com"},
+	}
+
+	d2 := pterm.TableData{
+		{"Firstname", "Lastname"},
+		{"Paul", "Dean"},
+		{"Callie", "Mckay"},
+		{"Libby", "Camacho"},
+	}
+
+	t1 := pterm.DefaultTable.WithHasHeader().WithData(d3)
+	t2 := pterm.DefaultTable.WithHasHeader().WithData(d2)
+
+	tg := pterm.DefaultGroupTable
+	tg.Append(t1, t2)
+
+	testza.AssertEqual(t, d3, tg.Tables[0].Data)
+	testza.AssertEqual(t, d2, tg.Tables[1].Data)
+}
+
+func TestTableGroupPrinter_WithBoxed(t *testing.T) {
+	_, err := pterm.DefaultGroupTable.WithBoxed(true).Srender()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTableGroupPrinter_WithShare(t *testing.T) {
+	d3 := pterm.TableData{
+		{"Firstname", "Lastname", "Email"},
+		{"Paul", "Dean", "nisi.dictum.augue@velitAliquam.co.uk"},
+		{"Callie", "Mckay", "egestas.nunc.sed@est.com"},
+		{"Libby", "Camacho", "aliquet.lobortis@semper.com"},
+	}
+
+	d2 := pterm.TableData{
+		{"Firstname", "Lastname"},
+		{"Paul", "Dean"},
+		{"Callie", "Mckay"},
+		{"Libby", "Camacho"},
+	}
+
+	t1 := pterm.DefaultTable.WithHasHeader().WithData(d3).WithSeparator("*")
+	t2 := pterm.DefaultTable.WithHasHeader().WithData(d2).WithSeparator("^")
+
+	tg := pterm.DefaultGroupTable.WithShare(true)
+	tg.Append(t1, t2).Srender()
+
+	testza.AssertEqual(t, tg.Tables[0].Separator, tg.Tables[1].Separator)
+}
+
+func TestTableGroupPrinter_WithNoShare(t *testing.T) {
+	d3 := pterm.TableData{
+		{"Firstname", "Lastname", "Email"},
+		{"Paul", "Dean", "nisi.dictum.augue@velitAliquam.co.uk"},
+		{"Callie", "Mckay", "egestas.nunc.sed@est.com"},
+		{"Libby", "Camacho", "aliquet.lobortis@semper.com"},
+	}
+
+	d2 := pterm.TableData{
+		{"Firstname", "Lastname"},
+		{"Paul", "Dean"},
+		{"Callie", "Mckay"},
+		{"Libby", "Camacho"},
+	}
+
+	p1 := pterm.TablePrinter{}
+	t1 := p1.WithHasHeader().WithData(d3).WithSeparator("*")
+	p2 := pterm.TablePrinter{}
+	t2 := p2.WithHasHeader().WithData(d2).WithSeparator("^")
+
+	tg := pterm.TableGroup{}
+	tg.Append(t1, t2).Srender()
+
+	testza.AssertNotEqual(t, tg.Tables[0].Separator, tg.Tables[1].Separator)
+}
+
+func TestTableGroupPrinter_WithHasHeader(t *testing.T) {
+	tg := pterm.TableGroup{}
+	p2 := tg.WithHasHeader()
+
+	testza.AssertTrue(t, p2.HasHeader)
+}
+
+func TestTableGroupPrinter_WithHeaderStyle(t *testing.T) {
+	s := pterm.NewStyle(pterm.FgRed, pterm.BgBlue, pterm.Bold)
+	p := pterm.TableGroup{}
+	p2 := p.WithHeaderStyle(s)
+
+	testza.AssertEqual(t, s, p2.HeaderStyle)
+}
+
+func TestTableGroupPrinter_WithSeparator(t *testing.T) {
+	p := pterm.TableGroup{}
+	p2 := p.WithSeparator("-")
+
+	testza.AssertEqual(t, "-", p2.Separator)
+}
+
+func TestTableGroupPrinter_WithSeparatorStyle(t *testing.T) {
+	s := pterm.NewStyle(pterm.FgRed, pterm.BgBlue, pterm.Bold)
+	p := pterm.TableGroup{}
+	p2 := p.WithSeparatorStyle(s)
+
+	testza.AssertEqual(t, s, p2.SeparatorStyle)
+}
+
+func TestTableGroupPrinter_WithHorizontalSeparator(t *testing.T) {
+	p := pterm.TableGroup{}
+	p2 := p.WithHorizontalSeparator("-")
+
+	testza.AssertEqual(t, "-", p2.HSeparator)
+}
+
+func TestTableGroupPrinter_WithHorizontalSeparatorWrongSize(t *testing.T) {
+	p := pterm.DefaultGroupTable
+	p2 := p.WithHorizontalSeparator(" - ")
+
+	testza.AssertEqual(t, "-", p2.HSeparator)
+}
+
+func TestTableGroupPrinter_WithHorizontalSeparatorStyle(t *testing.T) {
+	s := pterm.NewStyle(pterm.FgRed, pterm.BgBlue, pterm.Bold)
+	p := pterm.TableGroup{}
+	p2 := p.WithHorizontalSeparatorStyle(s)
+
+	testza.AssertEqual(t, s, p2.HSeparatorStyle)
+}
+
+func TestTableGroupPrinter_WithStyle(t *testing.T) {
+	s := pterm.NewStyle(pterm.FgRed, pterm.BgBlue, pterm.Bold)
+	p := pterm.TableGroup{}
+	p2 := p.WithStyle(s)
+
+	testza.AssertEqual(t, s, p2.Style)
+}


### PR DESCRIPTION
### Description
It's very early probably with bugs approach on grouping printers together and share styling across them.
### Scope
> What is affected by this pull request?

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Other

### Related Issue
Proposal #224 


### To-Do Checklist
- [x] I tested my changes
- [x] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods
