### PR TITLE
ci: fixed flaky tests on linux/macos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ vendor/
 
 # This is where we test stuff
 /experimenting/
+
+/.history
+/.vscode

--- a/utils_test.go
+++ b/utils_test.go
@@ -190,11 +190,13 @@ func testDoesNotOutput(t *testing.T, logic func(w io.Writer)) {
 
 var outBuf bytes.Buffer
 
+// setupStdoutCapture sets up a fake stdout capture.
 func setupStdoutCapture() {
 	outBuf.Reset()
 	pterm.SetDefaultOutput(&outBuf)
 }
 
+// teardownStdoutCapture restores the real stdout.
 func teardownStdoutCapture() {
 	pterm.SetDefaultOutput(os.Stdout)
 }


### PR DESCRIPTION
### Description
- replaced stdout capture with an in-memory buffer
- fixed non-windows platforms
- possibly increased the speed of tests (1.650s)

### Scope
> What is affected by this pull request?

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Other

### Related Issue
Fixes https://github.com/pterm/pterm/issues/289


### To-Do Checklist
- [x] I tested my changes
- [x] I have commented every method that I created/changed
- [ ] **N/A** I updated the examples to fit with my changes
- [ ] **N/A** I have added tests for my newly created methods
