### PR TITLE
feat: use fallback color in `BigTextPrinter` when `RGB` is not supported

### DIFF
--- a/bigtext_printer.go
+++ b/bigtext_printer.go
@@ -1,6 +1,7 @@
 package pterm
 
 import (
+	"github.com/gookit/color"
 	"strings"
 
 	"github.com/mattn/go-runewidth"
@@ -141,7 +142,7 @@ func (p BigTextPrinter) Srender() (string, error) {
 				letterLine += strings.Repeat(" ", maxLetterWidth-letterLineLength)
 			}
 
-			if letter.RGB != (RGB{}) {
+			if letter.RGB != (RGB{}) && color.IsSupportRGBColor() {
 				ret += letter.RGB.Sprint(letterLine)
 			} else {
 				ret += letter.Style.Sprint(letterLine)

--- a/bigtext_printer.go
+++ b/bigtext_printer.go
@@ -142,7 +142,7 @@ func (p BigTextPrinter) Srender() (string, error) {
 				letterLine += strings.Repeat(" ", maxLetterWidth-letterLineLength)
 			}
 
-			if letter.RGB != (RGB{}) && color.IsSupportRGBColor() {
+			if letter.RGB != (RGB{}) && (color.IsSupportRGBColor() || internal.RunsInCi()) {
 				ret += letter.RGB.Sprint(letterLine)
 			} else {
 				ret += letter.Style.Sprint(letterLine)

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,0 +1,8 @@
+package internal
+
+import "os"
+
+// RunsInCi returns true if the current build is running on a CI server.
+func RunsInCi() bool {
+	return os.Getenv("CI") != ""
+}


### PR DESCRIPTION
feat: use fallback color in `BigTextPrinter` when `RGB` is not supported