### PR TITLE
fix: the interactive confirm answers should match the confirm/reject text

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -88,5 +88,9 @@ issues:
     - linters:
         - gocritic
       text: "unnecessaryDefer:"
+    - linters:
+        - gocritic
+      text: "preferDecodeRune:"
 service:
   golangci-lint-version: 1.31.x # use the fixed version to not introduce new linters unexpectedly
+

--- a/interactive_confirm_printer_test.go
+++ b/interactive_confirm_printer_test.go
@@ -76,6 +76,45 @@ func TestInteractiveConfirmPrinter_WithRejectText(t *testing.T) {
 	testza.AssertEqual(t, p.RejectText, "reject")
 }
 
+func TestInteractiveConfirmPrinter_CustomAnswers(t *testing.T) {
+	p := pterm.DefaultInteractiveConfirm.WithRejectText("reject").WithConfirmText("accept")
+	tests := []struct {
+		name     string
+		key      rune
+		expected bool
+	}{
+		{
+			name:     "Accept_upper_case",
+			key:      'A',
+			expected: true,
+		},
+		{
+			name:     "Accept_lower",
+			key:      'a',
+			expected: true,
+		},
+		{
+			name:     "Reject_upper_case",
+			key:      'R',
+			expected: false,
+		},
+		{
+			name:     "Reject_lower_case",
+			key:      'r',
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			go func() {
+				keyboard.SimulateKeyPress(tc.key)
+			}()
+			result, _ := p.Show()
+			testza.AssertEqual(t, result, tc.expected)
+		})
+	}
+}
+
 func TestInteractiveConfirmPrinter_WithSuffixStyle(t *testing.T) {
 	style := pterm.NewStyle(pterm.FgRed)
 	p := pterm.DefaultInteractiveConfirm.WithSuffixStyle(style)


### PR DESCRIPTION
### Description

The lib allows specifying the confirmation and rejection text but hardcodes the answers to yes or no, this aims to fix that.
Fixing this issue helps with internationalisation, for example, in most Latin based languages the suffix should be `[s/N]` instead of `[y/N]` (in French it would probably be `[o/N]`)

**Note**: I've disabled the `gocritic` complaint regarding `preferDecodeRune` as I don't think it would make sense to use `utf8.DecodeRuneInString` in this situation.
Ideally, `gocritic` should allow disabling the rule for a single line with a comment in the code, but that doesn't seem to be possible at the moment...

### Scope

Interactive Confirm Printer

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other


### To-Do Checklist
- [x] I tested my changes
- [x] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods
