### PR TITLE
refactor(interactive_printers): change `DefaultText` to `Label` on InteractiveConfirm and InteractiveMultiselect

### DIFF
--- a/interactive_confirm_printer.go
+++ b/interactive_confirm_printer.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
+	
 	"atomicgo.dev/cursor"
 	"atomicgo.dev/keyboard"
 	"atomicgo.dev/keyboard/keys"
@@ -16,8 +16,8 @@ var (
 	// Pressing enter without typing "y" or "n" will return the configured default value (by default set to "no").
 	DefaultInteractiveConfirm = InteractiveConfirmPrinter{
 		DefaultValue: false,
-		DefaultText:  "Please confirm",
-		TextStyle:    &ThemeDefault.PrimaryStyle,
+		Label:        "Please confirm",
+		LabelStyle:   &ThemeDefault.PrimaryStyle,
 		ConfirmText:  "Yes",
 		ConfirmStyle: &ThemeDefault.SuccessMessageStyle,
 		RejectText:   "No",
@@ -29,8 +29,8 @@ var (
 // InteractiveConfirmPrinter is a printer for interactive confirm prompts.
 type InteractiveConfirmPrinter struct {
 	DefaultValue bool
-	DefaultText  string
-	TextStyle    *Style
+	Label        string
+	LabelStyle   *Style
 	ConfirmText  string
 	ConfirmStyle *Style
 	RejectText   string
@@ -39,8 +39,15 @@ type InteractiveConfirmPrinter struct {
 }
 
 // WithDefaultText sets the default text.
+//
+// Deprecated: use InteractiveConfirmPrinter.WithLabel instead.
 func (p InteractiveConfirmPrinter) WithDefaultText(text string) *InteractiveConfirmPrinter {
-	p.DefaultText = text
+	return p.WithLabel(text)
+}
+
+// WithLabel sets the label text.
+func (p InteractiveConfirmPrinter) WithLabel(text string) *InteractiveConfirmPrinter {
+	p.Label = text
 	return &p
 }
 
@@ -51,8 +58,15 @@ func (p InteractiveConfirmPrinter) WithDefaultValue(value bool) *InteractiveConf
 }
 
 // WithTextStyle sets the text style.
+//
+// Deprecated: use InteractiveConfirmPrinter.WithLabelStyle instead.
 func (p InteractiveConfirmPrinter) WithTextStyle(style *Style) *InteractiveConfirmPrinter {
-	p.TextStyle = style
+	return p.WithLabelStyle(style)
+}
+
+// WithLabelStyle sets the label style.
+func (p InteractiveConfirmPrinter) WithLabelStyle(style *Style) *InteractiveConfirmPrinter {
+	p.LabelStyle = style
 	return &p
 }
 
@@ -93,21 +107,21 @@ func (p InteractiveConfirmPrinter) WithSuffixStyle(style *Style) *InteractiveCon
 //  pterm.Println(result)
 func (p InteractiveConfirmPrinter) Show(text ...string) (bool, error) {
 	var result bool
-
+	
 	if len(text) == 0 || text[0] == "" {
-		text = []string{p.DefaultText}
+		text = []string{p.Label}
 	}
-
-	p.TextStyle.Print(text[0] + " " + p.getSuffix() + ": ")
+	
+	p.LabelStyle.Print(text[0] + " " + p.getSuffix() + ": ")
 	y, n := p.getShortHandles()
-
+	
 	err := keyboard.Listen(func(keyInfo keys.Key) (stop bool, err error) {
 		key := keyInfo.Code
 		char := strings.ToLower(keyInfo.String())
 		if err != nil {
 			return false, fmt.Errorf("failed to get key: %w", err)
 		}
-
+		
 		switch key {
 		case keys.RuneKey:
 			switch char {
@@ -145,7 +159,7 @@ func (p InteractiveConfirmPrinter) Show(text ...string) (bool, error) {
 func (p InteractiveConfirmPrinter) getShortHandles() (string, string) {
 	y := strings.ToLower(string([]rune(p.ConfirmText)[0]))
 	n := strings.ToLower(string([]rune(p.RejectText)[0]))
-
+	
 	return y, n
 }
 
@@ -157,6 +171,6 @@ func (p InteractiveConfirmPrinter) getSuffix() string {
 	} else {
 		n = strings.ToUpper(n)
 	}
-
+	
 	return p.SuffixStyle.Sprintf("[%s/%s]", y, n)
 }

--- a/interactive_confirm_printer_test.go
+++ b/interactive_confirm_printer_test.go
@@ -2,11 +2,11 @@ package pterm_test
 
 import (
 	"testing"
-
+	
 	"atomicgo.dev/keyboard"
 	"atomicgo.dev/keyboard/keys"
 	"github.com/MarvinJWendt/testza"
-
+	
 	"github.com/pterm/pterm"
 )
 
@@ -62,7 +62,12 @@ func TestInteractiveConfirmPrinter_WithConfirmText(t *testing.T) {
 
 func TestInteractiveConfirmPrinter_WithDefaultText(t *testing.T) {
 	p := pterm.DefaultInteractiveConfirm.WithDefaultText("default")
-	testza.AssertEqual(t, p.DefaultText, "default")
+	testza.AssertEqual(t, p.Label, "default")
+}
+
+func TestInteractiveConfirmPrinter_WithLabel(t *testing.T) {
+	p := pterm.DefaultInteractiveConfirm.WithLabel("default")
+	testza.AssertEqual(t, p.Label, "default")
 }
 
 func TestInteractiveConfirmPrinter_WithRejectStyle(t *testing.T) {
@@ -124,5 +129,11 @@ func TestInteractiveConfirmPrinter_WithSuffixStyle(t *testing.T) {
 func TestInteractiveConfirmPrinter_WithTextStyle(t *testing.T) {
 	style := pterm.NewStyle(pterm.FgRed)
 	p := pterm.DefaultInteractiveConfirm.WithTextStyle(style)
-	testza.AssertEqual(t, p.TextStyle, style)
+	testza.AssertEqual(t, p.LabelStyle, style)
+}
+
+func TestInteractiveConfirmPrinter_WithLabelStyle(t *testing.T) {
+	style := pterm.NewStyle(pterm.FgRed)
+	p := pterm.DefaultInteractiveConfirm.WithLabelStyle(style)
+	testza.AssertEqual(t, p.LabelStyle, style)
 }

--- a/interactive_continue_printer.go
+++ b/interactive_continue_printer.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
+	
 	"atomicgo.dev/cursor"
 	"atomicgo.dev/keyboard"
 	"atomicgo.dev/keyboard/keys"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
-
+	
 	"github.com/pterm/pterm/internal"
 )
 
@@ -20,8 +20,8 @@ var (
 	// Pressing enter without typing any letter will return the configured default value (by default set to "yes", the fisrt option).
 	DefaultInteractiveContinue = InteractiveContinuePrinter{
 		DefaultValueIndex: 0,
-		DefaultText:       "Do you want to continue",
-		TextStyle:         &ThemeDefault.PrimaryStyle,
+		Label:             "Do you want to continue",
+		LabelStyle:        &ThemeDefault.PrimaryStyle,
 		Options:           []string{"yes", "no", "all", "cancel"},
 		OptionsStyle:      &ThemeDefault.SuccessMessageStyle,
 		SuffixStyle:       &ThemeDefault.SecondaryStyle,
@@ -31,8 +31,8 @@ var (
 // InteractiveContinuePrinter is a printer for interactive continue prompts.
 type InteractiveContinuePrinter struct {
 	DefaultValueIndex int
-	DefaultText       string
-	TextStyle         *Style
+	Label             string
+	LabelStyle        *Style
 	Options           []string
 	OptionsStyle      *Style
 	Handles           []string
@@ -41,8 +41,15 @@ type InteractiveContinuePrinter struct {
 }
 
 // WithDefaultText sets the default text.
+//
+// Deprecated: use InteractiveContinuePrinter.WithLabel instead.
 func (p InteractiveContinuePrinter) WithDefaultText(text string) *InteractiveContinuePrinter {
-	p.DefaultText = text
+	return p.WithLabel(text)
+}
+
+// WithLabel sets the label text.
+func (p InteractiveContinuePrinter) WithLabel(text string) *InteractiveContinuePrinter {
+	p.Label = text
 	return &p
 }
 
@@ -67,8 +74,15 @@ func (p InteractiveContinuePrinter) WithDefaultValue(value string) *InteractiveC
 }
 
 // WithTextStyle sets the text style.
+//
+// Deprecated: use InteractiveContinuePrinter.WithLabelStyle instead.
 func (p InteractiveContinuePrinter) WithTextStyle(style *Style) *InteractiveContinuePrinter {
-	p.TextStyle = style
+	return p.WithLabelStyle(style)
+}
+
+// WithLabelStyle sets the label style.
+func (p InteractiveContinuePrinter) WithLabelStyle(style *Style) *InteractiveContinuePrinter {
+	p.LabelStyle = style
 	return &p
 }
 
@@ -115,20 +129,20 @@ func (p InteractiveContinuePrinter) WithSuffixStyle(style *Style) *InteractiveCo
 //  pterm.Println(result)
 func (p InteractiveContinuePrinter) Show(text ...string) (string, error) {
 	var result string
-
+	
 	if len(text) == 0 || text[0] == "" {
-		text = []string{p.DefaultText}
+		text = []string{p.Label}
 	}
-
-	p.TextStyle.Print(text[0] + " " + p.getSuffix() + ": ")
-
+	
+	p.LabelStyle.Print(text[0] + " " + p.getSuffix() + ": ")
+	
 	err := keyboard.Listen(func(keyInfo keys.Key) (stop bool, err error) {
 		if err != nil {
 			return false, fmt.Errorf("failed to get key: %w", err)
 		}
 		key := keyInfo.Code
 		char := keyInfo.String()
-
+		
 		switch key {
 		case keys.RuneKey:
 			for i, c := range p.Handles {
@@ -164,7 +178,7 @@ func (p InteractiveContinuePrinter) getShortHandles() []string {
 		handles = append(handles, strings.ToLower(string([]rune(option)[0])))
 	}
 	handles[p.DefaultValueIndex] = strings.ToUpper(handles[p.DefaultValueIndex])
-
+	
 	return handles
 }
 
@@ -173,7 +187,7 @@ func (p *InteractiveContinuePrinter) setDefaultHandles() {
 	if p.ShowShortHandles {
 		p.Handles = p.getShortHandles()
 	}
-
+	
 	if p.Handles == nil || len(p.Handles) == 0 {
 		p.Handles = make([]string, len(p.Options))
 		copy(p.Handles, p.Options)
@@ -186,6 +200,6 @@ func (p *InteractiveContinuePrinter) getSuffix() string {
 	if p.Handles == nil || len(p.Handles) != len(p.Options) {
 		p.setDefaultHandles()
 	}
-
+	
 	return p.SuffixStyle.Sprintf("[%s]", strings.Join(p.Handles, "/"))
 }

--- a/interactive_continue_printer_test.go
+++ b/interactive_continue_printer_test.go
@@ -2,11 +2,11 @@ package pterm_test
 
 import (
 	"testing"
-
+	
 	"atomicgo.dev/keyboard"
 	"atomicgo.dev/keyboard/keys"
 	"github.com/MarvinJWendt/testza"
-
+	
 	"github.com/pterm/pterm"
 )
 
@@ -133,7 +133,12 @@ func TestInteractiveContinuePrinter_WithHandles(t *testing.T) {
 
 func TestInteractiveContinuePrinter_WithDefaultText(t *testing.T) {
 	p := pterm.DefaultInteractiveContinue.WithDefaultText("default")
-	testza.AssertEqual(t, p.DefaultText, "default")
+	testza.AssertEqual(t, p.Label, "default")
+}
+
+func TestInteractiveContinuePrinter_WithLabel(t *testing.T) {
+	p := pterm.DefaultInteractiveContinue.WithLabel("default")
+	testza.AssertEqual(t, p.Label, "default")
 }
 
 func TestInteractiveContinuePrinter_CustomAnswers(t *testing.T) {
@@ -179,5 +184,11 @@ func TestInteractiveContinuePrinter_WithSuffixStyle(t *testing.T) {
 func TestInteractiveContinuePrinter_WithTextStyle(t *testing.T) {
 	style := pterm.NewStyle(pterm.FgRed)
 	p := pterm.DefaultInteractiveContinue.WithTextStyle(style)
-	testza.AssertEqual(t, p.TextStyle, style)
+	testza.AssertEqual(t, p.LabelStyle, style)
+}
+
+func TestInteractiveContinuePrinter_WithLabelStyle(t *testing.T) {
+	style := pterm.NewStyle(pterm.FgRed)
+	p := pterm.DefaultInteractiveContinue.WithLabelStyle(style)
+	testza.AssertEqual(t, p.LabelStyle, style)
 }


### PR DESCRIPTION
### Description
Changed `DefaultText` and `TextStyle` to `Label` and `LabelStyle` on InteractiveConfirm and InteractiveMultiselect. Deprecated methods with old names

### Scope
> What is affected by this pull request?

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [X] Other

### Related Issue
Fixes #405 


### To-Do Checklist
- [X] I tested my changes
- [X] I have commented every method that I created/changed
- [X] I updated the examples to fit with my changes
- [X] I have added tests for my newly created methods
