### PR TITLE
fix: slice bounds out of range on select printer

### DIFF
--- a/interactive_select_printer.go
+++ b/interactive_select_printer.go
@@ -2,6 +2,7 @@ package pterm
 
 import (
 	"fmt"
+	"math"
 	"sort"
 
 	"atomicgo.dev/cursor"
@@ -106,9 +107,9 @@ func (p *InteractiveSelectPrinter) Show(text ...string) (string, error) {
 		for i, option := range p.Options {
 			if option == p.DefaultOption {
 				p.selectedOption = i
-				if i > 0 {
-					p.displayedOptionsStart = i - 1
-					p.displayedOptionsEnd = i - 1 + maxHeight
+				if i > 0 && len(p.Options) > maxHeight {
+					p.displayedOptionsEnd = int(math.Min(float64(i-1+maxHeight), float64(len(p.Options))))
+					p.displayedOptionsStart = p.displayedOptionsEnd - maxHeight
 				} else {
 					p.displayedOptionsStart = 0
 					p.displayedOptionsEnd = maxHeight

--- a/interactive_select_printer_test.go
+++ b/interactive_select_printer_test.go
@@ -12,12 +12,12 @@ import (
 
 func TestInteractiveSelectPrinter_Show(t *testing.T) {
 	go func() {
-		keyboard.SimulateKeyPress(keys.Down)
-		keyboard.SimulateKeyPress(keys.Down)
+		keyboard.SimulateKeyPress(keys.Up)
+		keyboard.SimulateKeyPress(keys.Up)
 		keyboard.SimulateKeyPress(keys.Enter)
 	}()
-	result, _ := pterm.DefaultInteractiveSelect.WithOptions([]string{"a", "b", "c", "d", "e"}).WithDefaultOption("b").Show()
-	testza.AssertEqual(t, "d", result)
+	result, _ := pterm.DefaultInteractiveSelect.WithOptions([]string{"a", "b", "c", "d", "e", "f"}).WithDefaultOption("e").Show()
+	testza.AssertEqual(t, "c", result)
 }
 
 func TestInteractiveSelectPrinter_WithDefaultText(t *testing.T) {


### PR DESCRIPTION
Closes #419

### Description
Update InteractiveSelectPrinter.Show to fix out of range issue on `Options` slice when `DefaultOption` is set and its index is within `maxHeight` of the end of the `Options` array.

### Scope
> What is affected by this pull request?

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

### Related Issue
Fixes #419


### To-Do Checklist
- [x] I tested my changes
- [ ] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [x] I have updated tests for my newly modified methods
