### PR TITLE
feat: add optional mask to InteractiveTextInputPrinter for prompting for secrets/passwords/tokens

### DIFF
--- a/_examples/interactive_textinput/password/ci.go
+++ b/_examples/interactive_textinput/password/ci.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"os"
+	"time"
+
+	"atomicgo.dev/keyboard"
+	"atomicgo.dev/keyboard/keys"
+)
+
+// ------ Automation for CI ------
+// You can ignore this function, it is used to automatically run the demo and generate the example animation in our CI system.
+func init() {
+	if os.Getenv("CI") == "true" {
+		go func() {
+			time.Sleep(time.Second)
+			input := "Hello, World!"
+			for _, r := range input {
+				if r == '\n' {
+					keyboard.SimulateKeyPress(keys.Enter)
+				} else {
+					keyboard.SimulateKeyPress(r)
+				}
+				time.Sleep(time.Millisecond * 250)
+			}
+
+			keyboard.SimulateKeyPress(keys.Enter)
+		}()
+	}
+}

--- a/_examples/interactive_textinput/password/main.go
+++ b/_examples/interactive_textinput/password/main.go
@@ -1,0 +1,10 @@
+package main
+
+import "github.com/pterm/pterm"
+
+func main() {
+	result, _ := pterm.DefaultInteractiveTextInput.WithMask("*").Show("Enter your password")
+
+	logger := pterm.DefaultLogger
+	logger.Info("Password received", logger.Args("password", result))
+}

--- a/interactive_textinput_printer.go
+++ b/interactive_textinput_printer.go
@@ -15,6 +15,7 @@ var (
 	DefaultInteractiveTextInput = InteractiveTextInputPrinter{
 		DefaultText: "Input text",
 		TextStyle:   &ThemeDefault.PrimaryStyle,
+		Mask:        "",
 	}
 )
 
@@ -23,6 +24,7 @@ type InteractiveTextInputPrinter struct {
 	TextStyle   *Style
 	DefaultText string
 	MultiLine   bool
+	Mask        string
 
 	input      []string
 	cursorXPos int
@@ -45,6 +47,12 @@ func (p InteractiveTextInputPrinter) WithTextStyle(style *Style) *InteractiveTex
 // WithMultiLine sets the multi line flag.
 func (p InteractiveTextInputPrinter) WithMultiLine(multiLine ...bool) *InteractiveTextInputPrinter {
 	p.MultiLine = internal.WithBoolean(multiLine)
+	return &p
+}
+
+// WithMask sets the mask.
+func (p InteractiveTextInputPrinter) WithMask(mask string) *InteractiveTextInputPrinter {
+	p.Mask = mask
 	return &p
 }
 
@@ -200,6 +208,7 @@ func (p InteractiveTextInputPrinter) updateArea(area *AreaPrinter) string {
 		p.cursorYPos = 0
 	}
 	areaText := p.text
+
 	for i, s := range p.input {
 		if i < len(p.input)-1 {
 			areaText += s + "\n"
@@ -207,6 +216,11 @@ func (p InteractiveTextInputPrinter) updateArea(area *AreaPrinter) string {
 			areaText += s
 		}
 	}
+
+	if p.Mask != "" {
+		areaText = p.text + strings.Repeat(p.Mask, internal.GetStringMaxWidth(areaText)-internal.GetStringMaxWidth(p.text))
+	}
+
 	if p.cursorXPos+internal.GetStringMaxWidth(p.input[p.cursorYPos]) < 1 {
 		p.cursorXPos = -internal.GetStringMaxWidth(p.input[p.cursorYPos])
 	}

--- a/interactive_textinput_printer_test.go
+++ b/interactive_textinput_printer_test.go
@@ -3,6 +3,8 @@ package pterm_test
 import (
 	"testing"
 
+	"atomicgo.dev/keyboard"
+	"atomicgo.dev/keyboard/keys"
 	"github.com/MarvinJWendt/testza"
 
 	"github.com/pterm/pterm"
@@ -27,4 +29,15 @@ func TestInteractiveTextInputPrinter_WithTextStyle(t *testing.T) {
 	style := pterm.NewStyle(pterm.FgRed)
 	p := pterm.DefaultInteractiveTextInput.WithTextStyle(style)
 	testza.AssertEqual(t, p.TextStyle, style)
+}
+
+func TestInteractiveTextInputPrinter_WithMask(t *testing.T) {
+	go func() {
+		keyboard.SimulateKeyPress('a')
+		keyboard.SimulateKeyPress('b')
+		keyboard.SimulateKeyPress('c')
+		keyboard.SimulateKeyPress(keys.Enter)
+	}()
+	result, _ := pterm.DefaultInteractiveTextInput.WithMask("*").Show()
+	testza.AssertEqual(t, result, "abc")
 }


### PR DESCRIPTION
### Description
Adds `WithMask(string)` to `TestInteractiveTextInputPrinter` for prompting for secrets (such as passwords, API tokens, etc.)
It gives user feedback by showing `mask` characters instead of the actual characters.

Inspired by the [password](https://github.com/go-survey/survey#password) prompter from [go-survey/survey](https://github.com/go-survey/survey)

### Example

```go
result, _ := pterm.DefaultInteractiveTextInput.WithMask("*").Show()
```

### Scope
> What is affected by this pull request?

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Other


### To-Do Checklist
- [x] I tested my changes
- [x] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods
