### PR TITLE
If printing nothing for spinner, still sleep to avoid CPU usage

### DIFF
--- a/spinner_printer.go
+++ b/spinner_printer.go
@@ -140,7 +140,11 @@ func (s SpinnerPrinter) Start(text ...interface{}) (*SpinnerPrinter, error) {
 	go func() {
 		for s.IsActive {
 			for _, seq := range s.Sequence {
-				if !s.IsActive || RawOutput {
+				if !s.IsActive {
+					continue
+				}
+				if RawOutput {
+					time.Sleep(s.Delay)
 					continue
 				}
 


### PR DESCRIPTION
### Description
When RawOuput is set we do not want to print the spinner but without
sleep the refresh delay an very tight loop is run causing 100% CPU
on one goroutine.

### Scope
> What is affected by this pull request?

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

### Related Issue
Fixes #461


### To-Do Checklist
- [x] I tested my changes
- [x] I have commented every method that I created/changed
- [x] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods
