### PR TITLE
ci(workflows): Bump actions version, fix Node 12 deprecation warnings

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,13 +18,13 @@ jobs:
     steps:
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get dependencies
         run: go get -v -t -d ./...
@@ -37,4 +37,4 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: success() && matrix.os == 'windows-latest'
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -8,10 +8,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18
 


### PR DESCRIPTION
### Description

- Bump the `actions/checkout` version from `v2` (Node 12) to `v3` (Node 16).
- Bump the `actions/setup-go` version from `v2` (Node 12) to `v4` (Node 16).
- Bump the `codecov/codecov-action` version from `v1` to `v3`.

This PR fixes the Node 12 deprecation warnings displayed under Annotations in Actions runs, as all actions have been updated to Node 16.

### Scope

> What is affected by this pull request?

Workflows using `go.yml` and `golangci.yml`

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other


### To-Do Checklist
- [ ] I tested my changes
- [x] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [ ] I have added tests for my newly created methods
