### PR TITLE
add: progress bar filler from start

### DIFF
--- a/progressbar_printer.go
+++ b/progressbar_printer.go
@@ -228,11 +228,9 @@ func (p *ProgressbarPrinter) updateProgress() *ProgressbarPrinter {
 		barFiller = strings.Repeat(p.BarFiller, barMaxLength-barCurrentLength)
 	}
 
-	var bar string
+	bar := barFiller
 	if barCurrentLength > 0 {
-		bar = p.BarStyle.Sprint(strings.Repeat(p.BarCharacter, barCurrentLength)+p.LastCharacter) + barFiller
-	} else {
-		bar = ""
+		bar = p.BarStyle.Sprint(strings.Repeat(p.BarCharacter, barCurrentLength)+p.LastCharacter) + bar
 	}
 
 	if !RawOutput {

--- a/progressbar_printer_test.go
+++ b/progressbar_printer_test.go
@@ -66,6 +66,13 @@ func TestProgressbarPrinter_RemoveWhenDone(t *testing.T) {
 	testza.AssertFalse(t, p.IsActive)
 }
 
+func TestProgressbarPrinter_Start(t *testing.T) {
+	p := pterm.DefaultProgressbar
+	p2, _ := p.Start("Title")
+	testza.AssertEqual(t, "Title", p2.Title)
+	p.Stop()
+}
+
 func TestProgressbarPrinter_GenericStart(t *testing.T) {
 	p := pterm.DefaultProgressbar
 	p.GenericStart()

--- a/progressbar_printer_test.go
+++ b/progressbar_printer_test.go
@@ -66,7 +66,7 @@ func TestProgressbarPrinter_RemoveWhenDone(t *testing.T) {
 	testza.AssertFalse(t, p.IsActive)
 }
 
-func TestProgressbarPrinter_Start(t *testing.T) {
+func TestProgressbarPrinter_StartWithTitle(t *testing.T) {
 	p := pterm.DefaultProgressbar
 	p2, _ := p.Start("Title")
 	testza.AssertEqual(t, "Title", p2.Title)


### PR DESCRIPTION
### Description
I have modified the ProgressbarPrinter to print the filler starting from the beginning.

### Scope
> What is affected by this pull request?

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

### Related Issue
Fixes #495


### To-Do Checklist
- [x] I tested my changes
- [x] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [ ] I have added tests for my newly created methods
