### PR TITLE
refactor: use WithBoolean on multiselect printer

### DIFF
--- a/interactive_multiselect_printer.go
+++ b/interactive_multiselect_printer.go
@@ -85,8 +85,8 @@ func (p InteractiveMultiselectPrinter) WithMaxHeight(maxHeight int) *Interactive
 }
 
 // WithFilter sets the Filter option
-func (p InteractiveMultiselectPrinter) WithFilter(filter bool) *InteractiveMultiselectPrinter {
-	p.Filter = filter
+func (p InteractiveMultiselectPrinter) WithFilter(b ...bool) *InteractiveMultiselectPrinter {
+	p.Filter = internal.WithBoolean(b)
 	return &p
 }
 


### PR DESCRIPTION
### Description
Refactor `WithFilter()` method on `interactive_multiselect_printer.go` file.
Every boolean option on project used `WithBoolean` method on internals package except this file.

### Scope
> What is affected by this pull request?

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Other

### Related Issue
Fixes #


### To-Do Checklist
- [x] I tested my changes
- [ ] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [ ] I have added tests for my newly created methods
