### PR TITLE
Feature: using index in menu options

### DIFF
--- a/interactive_multiselect_printer.go
+++ b/interactive_multiselect_printer.go
@@ -116,6 +116,11 @@ func (p InteractiveMultiselectPrinter) WithOnInterruptFunc(exitFunc func()) *Int
 	return &p
 }
 
+// GetSelectedOptions returns selectedOptions.
+func (p InteractiveMultiselectPrinter) GetSelectedOptions() []int {
+	return p.selectedOptions
+}
+
 // Show shows the interactive multiselect menu and returns the selected entry.
 func (p *InteractiveMultiselectPrinter) Show(text ...string) ([]string, error) {
 	// should be the first defer statement to make sure it is executed last

--- a/interactive_multiselect_printer_test.go
+++ b/interactive_multiselect_printer_test.go
@@ -78,3 +78,16 @@ func TestInteractiveMultiselectPrinter_WithOnInterruptFunc(t *testing.T) {
 	p := pterm.DefaultInteractiveMultiselect.WithOnInterruptFunc(exitfunc)
 	testza.AssertEqual(t, reflect.ValueOf(p.OnInterruptFunc).Pointer(), reflect.ValueOf(exitfunc).Pointer())
 }
+
+func TestInteractiveMultiselectPrinter_GetDefaultSelectedOptions(t *testing.T) {
+	go func() {
+		keyboard.SimulateKeyPress(keys.Enter)
+		keyboard.SimulateKeyPress(keys.Down)
+		keyboard.SimulateKeyPress(keys.Down)
+		keyboard.SimulateKeyPress(keys.Enter)
+		keyboard.SimulateKeyPress(keys.Tab)
+	}()
+	ims := pterm.DefaultInteractiveMultiselect.WithOptions([]string{"a", "b", "c"})
+	ims.Show()
+	testza.AssertEqual(t, ims.GetSelectedOptions(), []int{0, 2})
+}

--- a/interactive_select_printer.go
+++ b/interactive_select_printer.go
@@ -86,6 +86,11 @@ func (p InteractiveSelectPrinter) WithFilter(b ...bool) *InteractiveSelectPrinte
 	return &p
 }
 
+// GetSelectedOption returns selectedOption.
+func (p InteractiveSelectPrinter) GetSelectedOption() int {
+	return p.selectedOption
+}
+
 // Show shows the interactive select menu and returns the selected entry.
 func (p *InteractiveSelectPrinter) Show(text ...string) (string, error) {
 	// should be the first defer statement to make sure it is executed last

--- a/interactive_select_printer.go
+++ b/interactive_select_printer.go
@@ -86,6 +86,14 @@ func (p InteractiveSelectPrinter) WithFilter(b ...bool) *InteractiveSelectPrinte
 	return &p
 }
 
+// WithDefaultSelectedOption sets selectedOption.
+// This method is like WithDefaultOption but it get option by index not string.
+func (p InteractiveSelectPrinter) WithDefaultSelectedOption(selectedOption int) *InteractiveSelectPrinter {
+	p.selectedOption = selectedOption
+	p.DefaultOption = ""
+	return &p
+}
+
 // GetSelectedOption returns selectedOption.
 func (p InteractiveSelectPrinter) GetSelectedOption() int {
 	return p.selectedOption

--- a/interactive_select_printer_test.go
+++ b/interactive_select_printer_test.go
@@ -66,3 +66,14 @@ func TestInteractiveSelectPrinter_WithFilter(t *testing.T) {
 	p := pterm.DefaultInteractiveSelect.WithFilter(false)
 	testza.AssertEqual(t, p.Filter, false)
 }
+
+func TestInteractiveSelectPrinter_GetSelectedOption(t *testing.T) {
+	go func() {
+		keyboard.SimulateKeyPress(keys.Down)
+		keyboard.SimulateKeyPress(keys.Down)
+		keyboard.SimulateKeyPress(keys.Enter)
+	}()
+	is := pterm.DefaultInteractiveSelect.WithOptions([]string{"a", "b", "c"})
+	is.Show()
+	testza.AssertEqual(t, is.GetSelectedOption(), 2)
+}

--- a/interactive_select_printer_test.go
+++ b/interactive_select_printer_test.go
@@ -77,3 +77,34 @@ func TestInteractiveSelectPrinter_GetSelectedOption(t *testing.T) {
 	is.Show()
 	testza.AssertEqual(t, is.GetSelectedOption(), 2)
 }
+
+func TestInteractiveSelectPrinter_WithDefaultSelectedOption(t *testing.T) {
+	// Check selectedOption value
+	p := pterm.DefaultInteractiveSelect.WithDefaultSelectedOption(2)
+	testza.AssertEqual(t, p.GetSelectedOption(), 2)
+
+	// Check behavior
+	go func() {
+		keyboard.SimulateKeyPress(keys.Up)
+		keyboard.SimulateKeyPress(keys.Up)
+		keyboard.SimulateKeyPress(keys.Enter)
+	}()
+	result, _ := pterm.DefaultInteractiveSelect.WithOptions([]string{"a", "b", "c"}).WithDefaultSelectedOption(2).Show()
+	testza.AssertEqual(t, result, "a")
+
+	// Check default values both with index and string
+	go func() {
+		keyboard.SimulateKeyPress(keys.Up)
+		keyboard.SimulateKeyPress(keys.Enter)
+	}()
+	result, _ = pterm.DefaultInteractiveSelect.WithOptions([]string{"a", "b", "c"}).WithDefaultSelectedOption(2).WithDefaultOption("b").Show()
+	testza.AssertEqual(t, result, "a")
+
+	go func() {
+		keyboard.SimulateKeyPress(keys.Up)
+		keyboard.SimulateKeyPress(keys.Up)
+		keyboard.SimulateKeyPress(keys.Enter)
+	}()
+	result, _ = pterm.DefaultInteractiveSelect.WithOptions([]string{"a", "b", "c"}).WithDefaultOption("b").WithDefaultSelectedOption(2).Show()
+	testza.AssertEqual(t, result, "a")
+}


### PR DESCRIPTION
### Description
We can use index of options. For interactive select printer it will useful for duplicated options and fix a bug.
If you have a some duplicated username on your menu, interactive select printer will just return a name that you selected regardless index and order. But we can return `selectedOption` in select and `selectedOptions` in multiselect.

### Scope
> What is affected by this pull request?

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Other

### Related Issue
Fixes #


### To-Do Checklist
- [x] I tested my changes
- [x] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods
