### PR TITLE
Fix duplicated multiselect

### DIFF
--- a/interactive_multiselect_printer.go
+++ b/interactive_multiselect_printer.go
@@ -153,7 +153,7 @@ func (p *InteractiveMultiselectPrinter) Show(text ...string) ([]string, error) {
 	p.displayedOptionsEnd = maxHeight
 
 	for _, option := range p.DefaultOptions {
-		p.selectOption(option)
+		p.selectOption(p.findOptionByText(option))
 	}
 
 	area, err := DefaultArea.Start(p.renderSelectMenu())
@@ -189,7 +189,7 @@ func (p *InteractiveMultiselectPrinter) Show(text ...string) ([]string, error) {
 		case p.KeySelect:
 			if len(p.fuzzySearchMatches) > 0 {
 				// Select option if not already selected
-				p.selectOption(p.fuzzySearchMatches[p.selectedOption])
+				p.selectOption(p.selectedOption)
 			}
 			area.Update(p.renderSelectMenu())
 		case keys.RuneKey:
@@ -317,9 +317,9 @@ func (p InteractiveMultiselectPrinter) findOptionByText(text string) int {
 	return -1
 }
 
-func (p *InteractiveMultiselectPrinter) isSelected(optionText string) bool {
+func (p *InteractiveMultiselectPrinter) isSelected(option int) bool {
 	for _, selectedOption := range p.selectedOptions {
-		if p.Options[selectedOption] == optionText {
+		if selectedOption == option {
 			return true
 		}
 	}
@@ -327,18 +327,18 @@ func (p *InteractiveMultiselectPrinter) isSelected(optionText string) bool {
 	return false
 }
 
-func (p *InteractiveMultiselectPrinter) selectOption(optionText string) {
-	if p.isSelected(optionText) {
+func (p *InteractiveMultiselectPrinter) selectOption(option int) {
+	if p.isSelected(option) {
 		// Remove from selected options
 		for i, selectedOption := range p.selectedOptions {
-			if p.Options[selectedOption] == optionText {
+			if selectedOption == option {
 				p.selectedOptions = append(p.selectedOptions[:i], p.selectedOptions[i+1:]...)
 				break
 			}
 		}
 	} else {
 		// Add to selected options
-		p.selectedOptions = append(p.selectedOptions, p.findOptionByText(optionText))
+		p.selectedOptions = append(p.selectedOptions, option)
 	}
 }
 
@@ -370,7 +370,7 @@ func (p *InteractiveMultiselectPrinter) renderSelectMenu() string {
 			continue
 		}
 		var checkmark string
-		if p.isSelected(option) {
+		if p.isSelected(i) {
 			checkmark = fmt.Sprintf("[%s]", p.Checkmark.Checked)
 		} else {
 			checkmark = fmt.Sprintf("[%s]", p.Checkmark.Unchecked)

--- a/interactive_multiselect_printer.go
+++ b/interactive_multiselect_printer.go
@@ -116,6 +116,11 @@ func (p InteractiveMultiselectPrinter) WithOnInterruptFunc(exitFunc func()) *Int
 	return &p
 }
 
+// GetSelectedOptions returns selectedOptions.
+func (p InteractiveMultiselectPrinter) GetSelectedOptions() []int {
+	return p.selectedOptions
+}
+
 // Show shows the interactive multiselect menu and returns the selected entry.
 func (p *InteractiveMultiselectPrinter) Show(text ...string) ([]string, error) {
 	// should be the first defer statement to make sure it is executed last

--- a/interactive_multiselect_printer_test.go
+++ b/interactive_multiselect_printer_test.go
@@ -91,3 +91,22 @@ func TestInteractiveMultiselectPrinter_GetDefaultSelectedOptions(t *testing.T) {
 	ims.Show()
 	testza.AssertEqual(t, ims.GetSelectedOptions(), []int{0, 2})
 }
+
+func TestInteractiveMultiselectPrinter_Show_Duplicated(t *testing.T) {
+	go func() {
+		keyboard.SimulateKeyPress(keys.Enter)
+		keyboard.SimulateKeyPress(keys.Down)
+		keyboard.SimulateKeyPress(keys.Down)
+		keyboard.SimulateKeyPress(keys.Enter)
+		keyboard.SimulateKeyPress(keys.Down)
+		keyboard.SimulateKeyPress(keys.Down)
+		keyboard.SimulateKeyPress(keys.Enter)
+		keyboard.SimulateKeyPress(keys.Tab)
+	}()
+	p := pterm.DefaultInteractiveMultiselect.
+		WithOptions([]string{"a", "a", "a", "a", "a", "a"})
+	r, _ := p.Show()
+
+	testza.AssertEqual(t, p.GetSelectedOptions(), []int{0, 2, 4})
+	testza.AssertEqual(t, r, []string{"a", "a", "a"})
+}

--- a/interactive_multiselect_printer_test.go
+++ b/interactive_multiselect_printer_test.go
@@ -78,3 +78,16 @@ func TestInteractiveMultiselectPrinter_WithOnInterruptFunc(t *testing.T) {
 	p := pterm.DefaultInteractiveMultiselect.WithOnInterruptFunc(exitfunc)
 	testza.AssertEqual(t, reflect.ValueOf(p.OnInterruptFunc).Pointer(), reflect.ValueOf(exitfunc).Pointer())
 }
+
+func TestInteractiveMultiselectPrinter_GetDefaultSelectedOptions(t *testing.T) {
+	go func() {
+		keyboard.SimulateKeyPress(keys.Enter)
+		keyboard.SimulateKeyPress(keys.Down)
+		keyboard.SimulateKeyPress(keys.Down)
+		keyboard.SimulateKeyPress(keys.Enter)
+		keyboard.SimulateKeyPress(keys.Tab)
+	}()
+	ims := pterm.DefaultInteractiveMultiselect.WithOptions([]string{"a", "b", "c"})
+	ims.Show()
+	testza.AssertEqual(t, ims.GetSelectedOptions(), []int{0, 2})
+}

--- a/interactive_select_printer.go
+++ b/interactive_select_printer.go
@@ -86,6 +86,11 @@ func (p InteractiveSelectPrinter) WithFilter(b ...bool) *InteractiveSelectPrinte
 	return &p
 }
 
+// GetSelectedOption returns selectedOption.
+func (p InteractiveSelectPrinter) GetSelectedOption() int {
+	return p.selectedOption
+}
+
 // Show shows the interactive select menu and returns the selected entry.
 func (p *InteractiveSelectPrinter) Show(text ...string) (string, error) {
 	// should be the first defer statement to make sure it is executed last

--- a/interactive_select_printer.go
+++ b/interactive_select_printer.go
@@ -86,6 +86,14 @@ func (p InteractiveSelectPrinter) WithFilter(b ...bool) *InteractiveSelectPrinte
 	return &p
 }
 
+// WithDefaultSelectedOption sets selectedOption.
+// This method is like WithDefaultOption but it get option by index not string.
+func (p InteractiveSelectPrinter) WithDefaultSelectedOption(selectedOption int) *InteractiveSelectPrinter {
+	p.selectedOption = selectedOption
+	p.DefaultOption = ""
+	return &p
+}
+
 // GetSelectedOption returns selectedOption.
 func (p InteractiveSelectPrinter) GetSelectedOption() int {
 	return p.selectedOption

--- a/interactive_select_printer_test.go
+++ b/interactive_select_printer_test.go
@@ -66,3 +66,14 @@ func TestInteractiveSelectPrinter_WithFilter(t *testing.T) {
 	p := pterm.DefaultInteractiveSelect.WithFilter(false)
 	testza.AssertEqual(t, p.Filter, false)
 }
+
+func TestInteractiveSelectPrinter_GetSelectedOption(t *testing.T) {
+	go func() {
+		keyboard.SimulateKeyPress(keys.Down)
+		keyboard.SimulateKeyPress(keys.Down)
+		keyboard.SimulateKeyPress(keys.Enter)
+	}()
+	is := pterm.DefaultInteractiveSelect.WithOptions([]string{"a", "b", "c"})
+	is.Show()
+	testza.AssertEqual(t, is.GetSelectedOption(), 2)
+}

--- a/interactive_select_printer_test.go
+++ b/interactive_select_printer_test.go
@@ -77,3 +77,34 @@ func TestInteractiveSelectPrinter_GetSelectedOption(t *testing.T) {
 	is.Show()
 	testza.AssertEqual(t, is.GetSelectedOption(), 2)
 }
+
+func TestInteractiveSelectPrinter_WithDefaultSelectedOption(t *testing.T) {
+	// Check selectedOption value
+	p := pterm.DefaultInteractiveSelect.WithDefaultSelectedOption(2)
+	testza.AssertEqual(t, p.GetSelectedOption(), 2)
+
+	// Check behavior
+	go func() {
+		keyboard.SimulateKeyPress(keys.Up)
+		keyboard.SimulateKeyPress(keys.Up)
+		keyboard.SimulateKeyPress(keys.Enter)
+	}()
+	result, _ := pterm.DefaultInteractiveSelect.WithOptions([]string{"a", "b", "c"}).WithDefaultSelectedOption(2).Show()
+	testza.AssertEqual(t, result, "a")
+
+	// Check default values both with index and string
+	go func() {
+		keyboard.SimulateKeyPress(keys.Up)
+		keyboard.SimulateKeyPress(keys.Enter)
+	}()
+	result, _ = pterm.DefaultInteractiveSelect.WithOptions([]string{"a", "b", "c"}).WithDefaultSelectedOption(2).WithDefaultOption("b").Show()
+	testza.AssertEqual(t, result, "a")
+
+	go func() {
+		keyboard.SimulateKeyPress(keys.Up)
+		keyboard.SimulateKeyPress(keys.Up)
+		keyboard.SimulateKeyPress(keys.Enter)
+	}()
+	result, _ = pterm.DefaultInteractiveSelect.WithOptions([]string{"a", "b", "c"}).WithDefaultOption("b").WithDefaultSelectedOption(2).Show()
+	testza.AssertEqual(t, result, "a")
+}


### PR DESCRIPTION
### Description
Library can't handle duplicated option names cause it's design is based on checking option names not indexes. This PR change this behavior without breaking backward compatibility.

### Scope
> What is affected by this pull request?

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

### Related Issue
Fixes https://github.com/pterm/pterm/issues/535

### To-Do Checklist
- [x] I tested my changes
- [ ] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods
