### PR TITLE
feat: add custom delimiters

### DIFF
--- a/interactive_confirm_printer.go
+++ b/interactive_confirm_printer.go
@@ -23,6 +23,7 @@ var (
 		RejectText:   "No",
 		RejectStyle:  &ThemeDefault.ErrorMessageStyle,
 		SuffixStyle:  &ThemeDefault.SecondaryStyle,
+		Delimiter: ": ",
 	}
 )
 
@@ -30,6 +31,7 @@ var (
 type InteractiveConfirmPrinter struct {
 	DefaultValue    bool
 	DefaultText     string
+	Delimiter string
 	TextStyle       *Style
 	ConfirmText     string
 	ConfirmStyle    *Style
@@ -93,6 +95,12 @@ func (p InteractiveConfirmPrinter) WithOnInterruptFunc(exitFunc func()) *Interac
 	return &p
 }
 
+// WithDelimiter sets the delimiter between the message and the input.
+func (p InteractiveConfirmPrinter) WithDelimiter(delimiter string) *InteractiveConfirmPrinter {
+	p.Delimiter = delimiter
+	return &p
+}
+
 // Show shows the confirm prompt.
 //
 // Example:
@@ -111,7 +119,7 @@ func (p InteractiveConfirmPrinter) Show(text ...string) (bool, error) {
 		text = []string{p.DefaultText}
 	}
 
-	p.TextStyle.Print(text[0] + " " + p.getSuffix() + ": ")
+	p.TextStyle.Print(text[0] + " " + p.getSuffix() + p.Delimiter)
 	y, n := p.getShortHandles()
 
 	var interrupted bool

--- a/interactive_confirm_printer_test.go
+++ b/interactive_confirm_printer_test.go
@@ -66,6 +66,11 @@ func TestInteractiveConfirmPrinter_WithDefaultText(t *testing.T) {
 	testza.AssertEqual(t, p.DefaultText, "default")
 }
 
+func TestInteractiveConfirmPrinter_WithDelimiter(t *testing.T) {
+	p := pterm.DefaultInteractiveConfirm.WithDelimiter(">>")
+	testza.AssertEqual(t, p.Delimiter, ">>")
+}
+
 func TestInteractiveConfirmPrinter_WithRejectStyle(t *testing.T) {
 	style := pterm.NewStyle(pterm.FgRed)
 	p := pterm.DefaultInteractiveConfirm.WithRejectStyle(style)

--- a/interactive_continue_printer.go
+++ b/interactive_continue_printer.go
@@ -14,24 +14,24 @@ import (
 	"github.com/pterm/pterm/internal"
 )
 
-var (
-	// DefaultInteractiveContinue is the default InteractiveContinue printer.
-	// Pressing "y" will return yes, "n" will return no, "a" returns all and "s" returns stop.
-	// Pressing enter without typing any letter will return the configured default value (by default set to "yes", the fisrt option).
-	DefaultInteractiveContinue = InteractiveContinuePrinter{
-		DefaultValueIndex: 0,
-		DefaultText:       "Do you want to continue",
-		TextStyle:         &ThemeDefault.PrimaryStyle,
-		Options:           []string{"yes", "no", "all", "cancel"},
-		OptionsStyle:      &ThemeDefault.SuccessMessageStyle,
-		SuffixStyle:       &ThemeDefault.SecondaryStyle,
-	}
-)
+// DefaultInteractiveContinue is the default InteractiveContinue printer.
+// Pressing "y" will return yes, "n" will return no, "a" returns all and "s" returns stop.
+// Pressing enter without typing any letter will return the configured default value (by default set to "yes", the fisrt option).
+var DefaultInteractiveContinue = InteractiveContinuePrinter{
+	DefaultValueIndex: 0,
+	DefaultText:       "Do you want to continue",
+	TextStyle:         &ThemeDefault.PrimaryStyle,
+	Options:           []string{"yes", "no", "all", "cancel"},
+	OptionsStyle:      &ThemeDefault.SuccessMessageStyle,
+	SuffixStyle:       &ThemeDefault.SecondaryStyle,
+	Delimiter:         ": ",
+}
 
 // InteractiveContinuePrinter is a printer for interactive continue prompts.
 type InteractiveContinuePrinter struct {
 	DefaultValueIndex int
 	DefaultText       string
+	Delimiter         string
 	TextStyle         *Style
 	Options           []string
 	OptionsStyle      *Style
@@ -108,6 +108,12 @@ func (p InteractiveContinuePrinter) WithSuffixStyle(style *Style) *InteractiveCo
 	return &p
 }
 
+// WithDelimiter sets the delimiter between the message and the input.
+func (p InteractiveContinuePrinter) WithDelimiter(delimiter string) *InteractiveContinuePrinter {
+	p.Delimiter = delimiter
+	return &p
+}
+
 // Show shows the continue prompt.
 //
 // Example:
@@ -121,7 +127,7 @@ func (p InteractiveContinuePrinter) Show(text ...string) (string, error) {
 		text = []string{p.DefaultText}
 	}
 
-	p.TextStyle.Print(text[0] + " " + p.getSuffix() + ": ")
+	p.TextStyle.Print(text[0] + " " + p.getSuffix() + p.Delimiter)
 
 	err := keyboard.Listen(func(keyInfo keys.Key) (stop bool, err error) {
 		if err != nil {

--- a/interactive_continue_printer_test.go
+++ b/interactive_continue_printer_test.go
@@ -136,6 +136,12 @@ func TestInteractiveContinuePrinter_WithDefaultText(t *testing.T) {
 	testza.AssertEqual(t, p.DefaultText, "default")
 }
 
+func TestInteractiveContinuePrinter_WithDelimiter(t *testing.T) {
+	p := pterm.DefaultInteractiveContinue.WithDelimiter(">>")
+	testza.AssertEqual(t, p.Delimiter, ">>")
+}
+
+
 func TestInteractiveContinuePrinter_CustomAnswers(t *testing.T) {
 	p := pterm.DefaultInteractiveContinue.WithOptions([]string{"next", "stop", "continue"})
 	tests := []struct {

--- a/interactive_textinput_printer.go
+++ b/interactive_textinput_printer.go
@@ -10,19 +10,19 @@ import (
 	"github.com/pterm/pterm/internal"
 )
 
-var (
-	// DefaultInteractiveTextInput is the default InteractiveTextInput printer.
-	DefaultInteractiveTextInput = InteractiveTextInputPrinter{
-		DefaultText: "Input text",
-		TextStyle:   &ThemeDefault.PrimaryStyle,
-		Mask:        "",
-	}
-)
+// DefaultInteractiveTextInput is the default InteractiveTextInput printer.
+var DefaultInteractiveTextInput = InteractiveTextInputPrinter{
+	DefaultText: "Input text",
+	Delimiter:   ": ",
+	TextStyle:   &ThemeDefault.PrimaryStyle,
+	Mask:        "",
+}
 
 // InteractiveTextInputPrinter is a printer for interactive select menus.
 type InteractiveTextInputPrinter struct {
 	TextStyle       *Style
 	DefaultText     string
+	Delimiter       string
 	MultiLine       bool
 	Mask            string
 	OnInterruptFunc func()
@@ -63,6 +63,13 @@ func (p InteractiveTextInputPrinter) WithOnInterruptFunc(exitFunc func()) *Inter
 	return &p
 }
 
+// WithDelimiter sets the delimiter between the message and the input.
+func (p InteractiveTextInputPrinter) WithDelimiter(delimiter string) *InteractiveTextInputPrinter {
+	p.Delimiter = delimiter
+	return &p
+}
+
+
 // Show shows the interactive select menu and returns the selected entry.
 func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 	// should be the first defer statement to make sure it is executed last
@@ -77,9 +84,9 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 	}
 
 	if p.MultiLine {
-		areaText = p.TextStyle.Sprintfln("%s %s :", text[0], ThemeDefault.SecondaryStyle.Sprint("[Press tab to submit]"))
+		areaText = p.TextStyle.Sprintfln("%s %s %s", text[0], ThemeDefault.SecondaryStyle.Sprint("[Press tab to submit]"), p.Delimiter)
 	} else {
-		areaText = p.TextStyle.Sprintf("%s: ", text[0])
+		areaText = p.TextStyle.Sprintf("%s%s", text[0], p.Delimiter)
 	}
 	p.text = areaText
 	area, err := DefaultArea.Start(areaText)

--- a/interactive_textinput_printer_test.go
+++ b/interactive_textinput_printer_test.go
@@ -16,6 +16,11 @@ func TestInteractiveTextInputPrinter_WithDefaultText(t *testing.T) {
 	testza.AssertEqual(t, p.DefaultText, "default")
 }
 
+func TestInteractiveTextInputPrinter_WithDelimiter(t *testing.T) {
+	p := pterm.DefaultInteractiveTextInput.WithDelimiter(">>")
+	testza.AssertEqual(t, p.Delimiter, ">>")
+}
+
 func TestInteractiveTextInputPrinter_WithMultiLine_true(t *testing.T) {
 	p := pterm.DefaultInteractiveTextInput.WithMultiLine()
 	testza.AssertTrue(t, p.MultiLine)


### PR DESCRIPTION
### Description
For text/confirm/continue inputs, there was no way to customise the delimiter between the prompt and the input.

Now you can use the `WithDelimiter` option to customise what this looks like.

### Scope
> What is affected by this pull request?

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Other

### To-Do Checklist
- [x] I tested my changes
- [ ] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods
