### PR TITLE
feat(select): added additional navigation keys

### DIFF
--- a/interactive_multiselect_printer.go
+++ b/interactive_multiselect_printer.go
@@ -240,7 +240,7 @@ func (p *InteractiveMultiselectPrinter) Show(text ...string) ([]string, error) {
 				p.selectedOptions = append(p.selectedOptions, i)
 			}
 			area.Update(p.renderSelectMenu())
-		case keys.Up:
+		case keys.Up, keys.CtrlP:
 			if len(p.fuzzySearchMatches) == 0 {
 				return false, nil
 			}
@@ -263,7 +263,7 @@ func (p *InteractiveMultiselectPrinter) Show(text ...string) ([]string, error) {
 			}
 
 			area.Update(p.renderSelectMenu())
-		case keys.Down:
+		case keys.Down, keys.CtrlN:
 			if len(p.fuzzySearchMatches) == 0 {
 				return false, nil
 			}

--- a/interactive_multiselect_printer_test.go
+++ b/interactive_multiselect_printer_test.go
@@ -33,6 +33,19 @@ func TestInteractiveMultiselectPrinter_Show_MaxHeightSlidingWindow(t *testing.T)
 	testza.AssertEqual(t, []string{"b", "e"}, result)
 }
 
+func TestInteractiveMultiselectPrinter_Show_AlternateNavigationKeys(t *testing.T) {
+	go func() {
+		keyboard.SimulateKeyPress(keys.CtrlN)
+		keyboard.SimulateKeyPress(keys.CtrlN)
+		keyboard.SimulateKeyPress(keys.CtrlN)
+		keyboard.SimulateKeyPress(keys.CtrlP)
+		keyboard.SimulateKeyPress(keys.Enter)
+		keyboard.SimulateKeyPress(keys.Tab)
+	}()
+	result, _ := pterm.DefaultInteractiveMultiselect.WithOptions([]string{"a", "b", "c", "d", "e"}).WithDefaultOptions([]string{"b"}).Show()
+	testza.AssertEqual(t, []string{"b", "c"}, result)
+}
+
 func TestInteractiveMultiselectPrinter_WithDefaultText(t *testing.T) {
 	p := pterm.DefaultInteractiveMultiselect.WithDefaultText("default")
 	testza.AssertEqual(t, p.DefaultText, "default")

--- a/interactive_select_printer.go
+++ b/interactive_select_printer.go
@@ -196,7 +196,7 @@ func (p *InteractiveSelectPrinter) Show(text ...string) (string, error) {
 			p.displayedOptions = append([]string{}, p.fuzzySearchMatches[p.displayedOptionsStart:p.displayedOptionsEnd]...)
 
 			area.Update(p.renderSelectMenu())
-		case keys.Up:
+		case keys.Up, keys.CtrlP:
 			if len(p.fuzzySearchMatches) == 0 {
 				return false, nil
 			}
@@ -219,7 +219,7 @@ func (p *InteractiveSelectPrinter) Show(text ...string) (string, error) {
 			}
 
 			area.Update(p.renderSelectMenu())
-		case keys.Down:
+		case keys.Down, keys.CtrlN:
 			if len(p.fuzzySearchMatches) == 0 {
 				return false, nil
 			}

--- a/interactive_select_printer_test.go
+++ b/interactive_select_printer_test.go
@@ -31,6 +31,17 @@ func TestInteractiveSelectPrinter_Show_MaxHeightSlidingWindow(t *testing.T) {
 	testza.AssertEqual(t, "c", result)
 }
 
+func TestInteractiveSelectPrinter_Show_AlternateNavigationKeys(t *testing.T) {
+	go func() {
+		keyboard.SimulateKeyPress(keys.CtrlN)
+		keyboard.SimulateKeyPress(keys.CtrlN)
+		keyboard.SimulateKeyPress(keys.CtrlP)
+		keyboard.SimulateKeyPress(keys.Enter)
+	}()
+	result, _ := pterm.DefaultInteractiveSelect.WithOptions([]string{"a", "b", "c", "d", "e"}).WithDefaultOption("b").Show()
+	testza.AssertEqual(t, "c", result)
+}
+
 func TestInteractiveSelectPrinter_WithDefaultText(t *testing.T) {
 	p := pterm.DefaultInteractiveSelect.WithDefaultText("default")
 	testza.AssertEqual(t, p.DefaultText, "default")


### PR DESCRIPTION
### Description
- Recreate https://github.com/pterm/pterm/pull/561
- This PR adds additional key binding Ctrl-p/Ctrl-n to move up and down in select/multiselect since these keys are quite commonly used

### Scope
> What is affected by this pull request?

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Other

### Related Issue
Fixes #


### To-Do Checklist
- [x] I tested my changes
- [ ] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods
