### PR TITLE
fix(heatmap): fix bug legend was not fully boxed

### DIFF
--- a/heatmap_printer.go
+++ b/heatmap_printer.go
@@ -585,11 +585,14 @@ func (p HeatmapPrinter) boxLegend(buffer *bytes.Buffer, legend string, legendCol
 }
 
 func (p HeatmapPrinter) generateSeparatorRow(buffer *bytes.Buffer, legend string, legendColWidth int, top bool) {
+	p.rgbLegendValue = 11
 	steps := len(p.RGBRange)
 	if steps < p.rgbLegendValue {
 		steps = p.rgbLegendValue
 	}
-	steps *= 3
+	if p.LegendOnlyColoredCells {
+		steps *= 3
+	}
 
 	var xValue int
 	if p.EnableRGB {


### PR DESCRIPTION
### Description
Fixed a bug regarding the length of the box of the legend.

### Scope
> What is affected by this pull request?
heatmap printer

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

### Related Issue
Fixes #582 


### To-Do Checklist
- [x] I tested my changes
- [ ] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [ ] I have added tests for my newly created methods
