### PR TITLE
fix: exit on `ctrl+c` in interactive printers by default

### DIFF
--- a/interactive_continue_printer.go
+++ b/interactive_continue_printer.go
@@ -2,7 +2,6 @@ package pterm
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"atomicgo.dev/cursor"
@@ -155,7 +154,7 @@ func (p InteractiveContinuePrinter) Show(text ...string) (string, error) {
 			result = p.Options[p.DefaultValueIndex]
 			return true, nil
 		case keys.CtrlC:
-			os.Exit(1)
+			internal.Exit(1)
 			return true, nil
 		}
 		return false, nil

--- a/internal/cancelation_signal.go
+++ b/internal/cancelation_signal.go
@@ -1,5 +1,7 @@
 package internal
 
+import "os"
+
 // NewCancelationSignal for keeping track of a cancelation
 func NewCancelationSignal(interruptFunc func()) (func(), func()) {
 	canceled := false
@@ -9,8 +11,12 @@ func NewCancelationSignal(interruptFunc func()) (func(), func()) {
 	}
 
 	exit := func() {
-		if canceled && interruptFunc != nil {
-			interruptFunc()
+		if canceled {
+			if interruptFunc != nil {
+				interruptFunc()
+			} else {
+				os.Exit(1)
+			}
 		}
 	}
 

--- a/internal/cancelation_signal.go
+++ b/internal/cancelation_signal.go
@@ -1,7 +1,5 @@
 package internal
 
-import "os"
-
 // NewCancelationSignal for keeping track of a cancelation
 func NewCancelationSignal(interruptFunc func()) (func(), func()) {
 	canceled := false
@@ -15,7 +13,7 @@ func NewCancelationSignal(interruptFunc func()) (func(), func()) {
 			if interruptFunc != nil {
 				interruptFunc()
 			} else {
-				os.Exit(1)
+				Exit(1)
 			}
 		}
 	}

--- a/internal/cancelation_signal_test.go
+++ b/internal/cancelation_signal_test.go
@@ -1,0 +1,54 @@
+package internal
+
+import (
+	"os"
+	"testing"
+)
+
+func TestNewCancelationSignal(t *testing.T) {
+    // Mock DefaultExitFunc
+    exitCalled := false
+    exitCode := 0
+    DefaultExitFunc = func(code int) {
+        exitCalled = true
+        exitCode = code
+    }
+    defer func() { DefaultExitFunc = os.Exit }() // Reset after tests
+
+    // Scenario 1: Testing cancel function
+    cancel, exit := NewCancelationSignal(nil)
+    if exitCalled {
+        t.Error("Exit function should not be called immediately after NewCancelationSignal")
+    }
+
+    // Scenario 2: Testing exit function without cancel
+    exit()
+    if exitCalled {
+        t.Error("Exit function should not be called when cancel is not set")
+    }
+
+    // Scenario 3: Testing cancel then exit with no interruptFunc
+    cancel()
+    exit()
+    if !exitCalled || exitCode != 1 {
+        t.Errorf("Expected Exit(1) to be called, exitCalled: %v, exitCode: %d", exitCalled, exitCode)
+    }
+
+    // Reset for next scenario
+    exitCalled = false
+    exitCode = 0
+
+    // Scenario 4: Testing cancel then exit with interruptFunc
+    interruptCalled := false
+    cancel, exit = NewCancelationSignal(func() {
+        interruptCalled = true
+    })
+    cancel()
+    exit()
+    if interruptCalled == false {
+        t.Error("Expected interruptFunc to be called")
+    }
+    if exitCalled {
+        t.Error("Exit should not be called when interruptFunc is provided")
+    }
+}

--- a/internal/exit.go
+++ b/internal/exit.go
@@ -1,0 +1,14 @@
+package internal
+
+import "os"
+
+// ExitFuncType is the type of function used to exit the program.
+type ExitFuncType func(int)
+
+// DefaultExitFunc is the default function used to exit the program.
+var DefaultExitFunc ExitFuncType = os.Exit
+
+// Exit calls the current exit function.
+func Exit(code int) {
+    DefaultExitFunc(code)
+}

--- a/internal/exit_test.go
+++ b/internal/exit_test.go
@@ -1,0 +1,23 @@
+package internal_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/pterm/pterm/internal"
+)
+
+func TestExit(t *testing.T) {
+    var lastExitCode int
+    internal.DefaultExitFunc = func(code int) {
+        lastExitCode = code
+    }
+
+    defer func() { internal.DefaultExitFunc = os.Exit }() 
+
+    internal.Exit(1)
+
+    if lastExitCode != 1 {
+        t.Errorf("Expected exit code 1, got %d", lastExitCode)
+    }
+}


### PR DESCRIPTION
### Description

Adding a default behavior to cancelation signals when they are nil.  
When a function is not provided it uses `os.Exit(1)` which is expected as default behavior.
Using an `internal.Exit` so we can mock `os.Exit` functionality for testing
Updated a test that was terminated by `os.Exit` behavior

### Scope
> What is affected by this pull request?

- [X] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

### Related Issue

Fixes https://github.com/pterm/pterm/issues/592

### To-Do Checklist
- [x] I tested my changes
- [ ] I have commented every method that I created/changed
- [ ] I updated the examples to fit with my changes
- [x] I have added tests for my newly created methods
