### PR TITLE
fix: graceful handling of odd args

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -8,4 +8,7 @@ var (
 
 	// ErrHexCodeIsInvalid - the given HEX code is invalid.
 	ErrHexCodeIsInvalid = errors.New("hex code is not valid")
+
+	// ErrKeyWithoutValue - an odd number of arguments was passed to a pterm Logger's Args method.
+	ErrKeyWithoutValue = "ERROR: key_without_value"
 )

--- a/logger.go
+++ b/logger.go
@@ -245,9 +245,8 @@ func (l Logger) sanitizeArgs(args []any) []any {
 	numArgs := len(args)
 	if numArgs > 0 && numArgs%2 != 0 {
 		if numArgs > 1 {
-			last := args[numArgs-1]
-			args = args[:numArgs-1]
-			args = append(args, []any{ErrKeyWithoutValue, last}...)
+			lastArg := args[numArgs-1]
+			args = append(args[:numArgs-1], []any{ErrKeyWithoutValue, lastArg}...)
 		} else {
 			args = []any{ErrKeyWithoutValue, args[0]}
 		}

--- a/logger.go
+++ b/logger.go
@@ -211,6 +211,8 @@ func (l Logger) Args(args ...any) []LoggerArgument {
 	var loggerArgs []LoggerArgument
 
 	// args are in the format of: key, value, key, value, key, value, ...
+	args = l.sanitizeArgs(args)
+
 	for i := 0; i < len(args); i += 2 {
 		key := Sprint(args[i])
 		value := args[i+1]
@@ -236,6 +238,20 @@ func (l Logger) ArgsFromMap(m map[string]any) []LoggerArgument {
 	}
 
 	return loggerArgs
+}
+
+func (l Logger) sanitizeArgs(args []any) []any {
+	numArgs := len(args)
+	if numArgs > 0 && numArgs%2 != 0 {
+		if numArgs > 1 {
+			last := args[numArgs-1]
+			args = args[:numArgs-1]
+			args = append(args, []any{ErrKeyWithoutValue, last}...)
+		} else {
+			args = []any{ErrKeyWithoutValue, args[0]}
+		}
+	}
+	return args
 }
 
 func (l Logger) getCallerInfo() (path string, line int) {

--- a/logger.go
+++ b/logger.go
@@ -240,6 +240,7 @@ func (l Logger) ArgsFromMap(m map[string]any) []LoggerArgument {
 	return loggerArgs
 }
 
+// sanitizeArgs inserts an error message into an args slice if an odd number of arguments is provided.
 func (l Logger) sanitizeArgs(args []any) []any {
 	numArgs := len(args)
 	if numArgs > 0 && numArgs%2 != 0 {

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,41 @@
+package pterm
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_sanitizeArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []any
+		expected []any
+	}{
+		{
+			name:     "pass_no_args",
+			args:     []any{},
+			expected: []any{},
+		},
+		{
+			name:     "pass_one_arg",
+			args:     []any{"foo"},
+			expected: []any{ErrKeyWithoutValue, "foo"},
+		},
+		{
+			name:     "pass_two_args",
+			args:     []any{"foo", "bar"},
+			expected: []any{"foo", "bar"},
+		},
+		{
+			name:     "pass_three_args",
+			args:     []any{"foo", "bar", "baz"},
+			expected: []any{"foo", "bar", ErrKeyWithoutValue, "baz"},
+		},
+	}
+	l := Logger{}
+	for _, tt := range tests {
+		if got := l.sanitizeArgs(tt.args); !reflect.DeepEqual(got, tt.expected) {
+			t.Errorf("sanitizeArgs: got: %v, expected: %v", got, tt.expected)
+		}
+	}
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -12,7 +12,7 @@ func Test_sanitizeArgs(t *testing.T) {
 		expected []any
 	}{
 		{
-			name:     "pass_no_args",
+			name:     "pass_zero_args",
 			args:     []any{},
 			expected: []any{},
 		},


### PR DESCRIPTION
### Description
Fixes https://github.com/pterm/pterm/issues/628. New output:

![image](https://github.com/pterm/pterm/assets/1795270/73464119-d9a9-499a-95a4-920ec143fd49)

### Scope
pterm logger's `Args` method.

- [X] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

### Related Issue
Fixes #628

### To-Do Checklist
- [X] I tested my changes
- [X] I have commented every method that I created/changed
- [X] I updated the examples to fit with my changes
- [X] I have added tests for my newly created methods
