### PR TITLE
Fix array out of bounds error in MultiPrinter.getString()

### DIFF
--- a/multi_live_printer.go
+++ b/multi_live_printer.go
@@ -1,12 +1,13 @@
 package pterm
 
 import (
-	"atomicgo.dev/schedule"
 	"bytes"
 	"io"
 	"os"
 	"strings"
 	"time"
+
+	"atomicgo.dev/schedule"
 )
 
 var DefaultMultiPrinter = MultiPrinter{
@@ -59,18 +60,20 @@ func (p *MultiPrinter) getString() string {
 		s = strings.Trim(s, "\n")
 
 		parts := strings.Split(s, "\r") // only get the last override
-		s = parts[len(parts)-1]
 
-		// check if s is empty, if so get one part before, repeat until not empty
-		for s == "" {
+		// check if the last part is empty, if so remove it, repeat until not
+		// empty. If there is no part left, don't do anything
+		for len(parts) > 0 && parts[len(parts)-1] == "" {
 			parts = parts[:len(parts)-1]
-			s = parts[len(parts)-1]
 		}
 
-		s = strings.Trim(s, "\n\r")
-		buffer.WriteString(s)
-		buffer.WriteString("\n")
+		if len(parts) > 0 {
+			s = strings.Trim(parts[len(parts)-1], "\n\r")
+			buffer.WriteString(s)
+			buffer.WriteString("\n")
+		}
 	}
+
 	return buffer.String()
 }
 

--- a/multi_live_printer_test.go
+++ b/multi_live_printer_test.go
@@ -1,0 +1,51 @@
+package pterm
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestMultiPrinterGetString(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		buf  string
+		want string
+	}{
+		{
+			name: "test1",
+			buf:  "test\rtest2\rtest3",
+			want: "test3\n",
+		},
+		{
+			name: "test2",
+			buf:  "\r\n",
+			want: "",
+		},
+		{
+			name: "test3",
+			buf:  "test",
+			want: "test\n",
+		},
+		{
+			name: "test4",
+			buf:  "",
+			want: "",
+		},
+	} {
+		test := test // pin for pre-go1.22 versions
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := DefaultMultiPrinter
+			p.buffers = []*bytes.Buffer{
+				bytes.NewBufferString(test.buf),
+			}
+
+			if test.want != p.getString() {
+				t.Errorf("got %v, want %v", p.getString(), test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When `parts` consists of all empty strings, this loop underruns with the following panic:

```
panic: runtime error: index out of range [-1] [recovered]
        panic: runtime error: index out of range [-1]

goroutine 9 [running]:
[...]
panic({0x6b3ee0?, 0xc0000204b0?})
        /usr/local/go/src/runtime/panic.go:785 +0x132
github.com/pterm/pterm.(*MultiPrinter).getString(0xc0000d6d00?)
        /workspace/pterm/multi_live_printer.go:67 +0x1c6
```

This commit fixes that by checking for the condition and using an empty string if there is nothing else available.