### PR TITLE
Suppress spinner line clearing in raw output mode

### DIFF
--- a/print.go
+++ b/print.go
@@ -119,7 +119,10 @@ func Fprint(writer io.Writer, a ...interface{}) {
 
 	for _, spinner := range activeSpinnerPrinters {
 		if spinner.IsActive && spinner.Writer == writer {
-			ret += sClearLine()
+			if !RawOutput {
+				ret += sClearLine()
+			}
+
 			ret += Sprinto(a...)
 			printed = true
 		}

--- a/spinner_printer.go
+++ b/spinner_printer.go
@@ -152,7 +152,7 @@ func (s SpinnerPrinter) Start(text ...interface{}) (*SpinnerPrinter, error) {
 		s.Text = Sprint(text...)
 	}
 
-	if RawOutput {
+	if RawOutput && s.Text != "" {
 		Fprintln(s.Writer, s.Text)
 	}
 
@@ -183,7 +183,7 @@ func (s SpinnerPrinter) Start(text ...interface{}) (*SpinnerPrinter, error) {
 // Stop terminates the SpinnerPrinter immediately.
 // The SpinnerPrinter will not resolve into anything.
 func (s *SpinnerPrinter) Stop() error {
-	if !s.IsActive {
+	if !s.IsActive || RawOutput {
 		return nil
 	}
 	s.IsActive = false
@@ -224,7 +224,11 @@ func (s *SpinnerPrinter) Info(message ...interface{}) {
 	if len(message) == 0 {
 		message = []interface{}{s.Text}
 	}
-	fClearLine(s.Writer)
+
+	if !RawOutput {
+		fClearLine(s.Writer)
+	}
+
 	Fprinto(s.Writer, s.InfoPrinter.Sprint(message...))
 	_ = s.Stop()
 }
@@ -239,7 +243,11 @@ func (s *SpinnerPrinter) Success(message ...interface{}) {
 	if len(message) == 0 {
 		message = []interface{}{s.Text}
 	}
-	fClearLine(s.Writer)
+
+	if !RawOutput {
+		fClearLine(s.Writer)
+	}
+
 	Fprinto(s.Writer, s.SuccessPrinter.Sprint(message...))
 	_ = s.Stop()
 }
@@ -254,7 +262,11 @@ func (s *SpinnerPrinter) Fail(message ...interface{}) {
 	if len(message) == 0 {
 		message = []interface{}{s.Text}
 	}
-	fClearLine(s.Writer)
+
+	if !RawOutput {
+		fClearLine(s.Writer)
+	}
+
 	Fprinto(s.Writer, s.FailPrinter.Sprint(message...))
 	_ = s.Stop()
 }
@@ -269,7 +281,11 @@ func (s *SpinnerPrinter) Warning(message ...interface{}) {
 	if len(message) == 0 {
 		message = []interface{}{s.Text}
 	}
-	fClearLine(s.Writer)
+
+	if !RawOutput {
+		fClearLine(s.Writer)
+	}
+
 	Fprinto(s.Writer, s.WarningPrinter.Sprint(message...))
 	_ = s.Stop()
 }


### PR DESCRIPTION
Spinners with `RawOutput` enabled print lots of blank characters to logs, because the spinners are always calling `sClearLine`. Additionally, spinners without any text print several blank newlines to logs.

e.g.
```
^M                                                                                ^MDoing something
^M                                                                                ^MSUCCESS: Doing something
```

This PR suppresses line clearing when `RawOutput` is true, and only writes to the output if there's any text to write.