### PR TITLE
Fix rounding factor panic

### DIFF
--- a/progressbar_printer.go
+++ b/progressbar_printer.go
@@ -350,6 +350,12 @@ func (p *ProgressbarPrinter) GetElapsedTime() time.Duration {
 }
 
 func (p *ProgressbarPrinter) parseElapsedTime() string {
+	// time.Duration.Round panics if the rounding factor is <= 0.
+	// Guard against invalid values by skipping rounding in this case.
+	if p.ElapsedTimeRoundingFactor <= 0 {
+		return p.GetElapsedTime().String()
+	}
+
 	s := p.GetElapsedTime().Round(p.ElapsedTimeRoundingFactor).String()
 	return s
 }

--- a/progressbar_printer_zero_rounding_test.go
+++ b/progressbar_printer_zero_rounding_test.go
@@ -1,0 +1,23 @@
+package pterm_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/MarvinJWendt/testza"
+
+	"github.com/pterm/pterm"
+)
+
+func TestProgressbarPrinter_NoPanicOnZeroRoundingFactor(t *testing.T) {
+	p := pterm.DefaultProgressbar
+	p.ElapsedTimeRoundingFactor = 0
+	p.ShowElapsedTime = true
+	p.Writer = io.Discard
+	pb, err := p.Start()
+	testza.AssertNoError(t, err)
+	testza.AssertNotPanics(t, func() {
+		pb.Add(1)
+	})
+	pb.Stop()
+}


### PR DESCRIPTION
## Summary
- prevent panic in progress bar when rounding factor is zero or negative
- test progress bar elapsed time rounding factor

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6844c0812c80832bb350ec306401fa10