### PR TITLE
Fix comment typo in SlogHandler

### DIFF
--- a/slog_handler.go
+++ b/slog_handler.go
@@ -84,7 +84,7 @@ func (s *SlogHandler) WithGroup(name string) slog.Handler {
 	return s
 }
 
-// NewSlogHandler returns a new logging handler that can be intrgrated with log/slog.
+// NewSlogHandler returns a new logging handler that can be integrated with log/slog.
 func NewSlogHandler(logger *Logger) *SlogHandler {
 	return &SlogHandler{logger: logger}
 }


### PR DESCRIPTION
## Summary
- correct a typo in the comment above `NewSlogHandler`

## Testing
- `gofmt -w slog_handler.go`

------
https://chatgpt.com/codex/tasks/task_e_6844c1aec624832bbc4a9f8ce02a0940