### PR TITLE
Fix typos in comments

### DIFF
--- a/progressbar_printer_test.go
+++ b/progressbar_printer_test.go
@@ -245,10 +245,10 @@ func TestProgressbarPrinter_OutputToWriters(t *testing.T) {
 		t.Run(testTitle, func(t *testing.T) {
 			stderr, err := testza.CaptureStderr(func(w io.Writer) error {
 				pb, err := pterm.DefaultProgressbar.WithTitle("Hello world").WithWriter(os.Stderr).Start()
-				time.Sleep(time.Second) // Required otherwise the goroutine doesn't run and the text isnt outputted
+				time.Sleep(time.Second) // Required otherwise the goroutine doesn't run and the text isn't outputted
 				testza.AssertNoError(t, err)
 				testCase.action(pb)
-				time.Sleep(time.Second) // Required otherwise the goroutine doesn't run and the text isnt updated
+				time.Sleep(time.Second) // Required otherwise the goroutine doesn't run and the text isn't updated
 				return nil
 			})
 

--- a/spinner_printer_test.go
+++ b/spinner_printer_test.go
@@ -240,10 +240,10 @@ func TestSpinnerPrinter_OutputToWriters(t *testing.T) {
 		t.Run(testTitle, func(t *testing.T) {
 			stderr, err := testza.CaptureStderr(func(w io.Writer) error {
 				sp, err := pterm.DefaultSpinner.WithText("Hello world").WithWriter(os.Stderr).Start()
-				time.Sleep(time.Second) // Required otherwise the goroutine doesn't run and the text isnt outputted
+				time.Sleep(time.Second) // Required otherwise the goroutine doesn't run and the text isn't outputted
 				testza.AssertNoError(t, err)
 				testCase.action(sp)
-				time.Sleep(time.Second) // Required otherwise the goroutine doesn't run and the text isnt updated
+				time.Sleep(time.Second) // Required otherwise the goroutine doesn't run and the text isn't updated
 				return nil
 			})
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -221,7 +221,7 @@ func captureStdout(f func(w io.Writer)) string {
 	return readStdout()
 }
 
-// readStdout reads the current stdout buffor. Assumes setupStdoutCapture() has been called before.
+// readStdout reads the current stdout buffer. Assumes setupStdoutCapture() has been called before.
 func readStdout() string {
 	content := outBuf.String()
 	outBuf.Reset()


### PR DESCRIPTION
## Summary
- correct small spelling errors in comments

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6844c3b959ac832baaa72b5490673246