### PR TITLE
fix(spinner): remove extra newline on start

### DIFF
--- a/spinner_printer.go
+++ b/spinner_printer.go
@@ -154,8 +154,6 @@ func (s SpinnerPrinter) Start(text ...any) (*SpinnerPrinter, error) {
 		s.Text = Sprint(text...)
 	}
 
-	Fprintln(s.Writer, s.Text)
-
 	go func() {
 		for s.IsActive {
 			for _, seq := range s.Sequence {


### PR DESCRIPTION
The spinner was printing an extra newline character upon starting, which caused layout issues in the terminal. The root cause is an unconditional `Fprintln` call in the `Start` method.

This removes the extra `Fprintln` to resolve the issue.

Fixes  #731
