### PR TITLE
fix: multiselect select/unselect all respects active filter

### DIFF
--- a/interactive_multiselect_printer.go
+++ b/interactive_multiselect_printer.go
@@ -246,14 +246,35 @@ func (p *InteractiveMultiselectPrinter) Show(text ...string) ([]string, error) {
 
 			area.Update(p.renderSelectMenu())
 		case keys.Left:
-			// Unselect all options
-			p.selectedOptions = []int{}
+			if p.fuzzySearchString != "" {
+				// Unselect only filtered options
+				for _, match := range p.fuzzySearchMatches {
+					if p.isSelected(match) {
+						p.selectOption(match)
+					}
+				}
+			} else {
+				// Unselect all options
+				p.selectedOptions = []int{}
+			}
 			area.Update(p.renderSelectMenu())
 		case keys.Right:
-			// Select all options
-			p.selectedOptions = []int{}
-			for i := 0; i < len(p.Options); i++ {
-				p.selectedOptions = append(p.selectedOptions, i)
+			if p.fuzzySearchString != "" {
+				// Select only filtered options
+				for _, match := range p.fuzzySearchMatches {
+					if !p.isSelected(match) {
+						idx := p.findOptionByText(match)
+						if idx >= 0 {
+							p.selectedOptions = append(p.selectedOptions, idx)
+						}
+					}
+				}
+			} else {
+				// Select all options
+				p.selectedOptions = []int{}
+				for i := 0; i < len(p.Options); i++ {
+					p.selectedOptions = append(p.selectedOptions, i)
+				}
 			}
 			area.Update(p.renderSelectMenu())
 		case keys.Up, keys.CtrlP:

--- a/interactive_multiselect_printer_test.go
+++ b/interactive_multiselect_printer_test.go
@@ -46,6 +46,45 @@ func TestInteractiveMultiselectPrinter_Show_AlternateNavigationKeys(t *testing.T
 	testza.AssertEqual(t, []string{"b", "c"}, result)
 }
 
+func TestInteractiveMultiselectPrinter_Show_SelectAllRespectsFilter(t *testing.T) {
+	go func() {
+		// Type "test" to filter options
+		keyboard.SimulateKeyPress(keys.Key{Code: keys.RuneKey, Runes: []rune{'t'}})
+		keyboard.SimulateKeyPress(keys.Key{Code: keys.RuneKey, Runes: []rune{'e'}})
+		keyboard.SimulateKeyPress(keys.Key{Code: keys.RuneKey, Runes: []rune{'s'}})
+		keyboard.SimulateKeyPress(keys.Key{Code: keys.RuneKey, Runes: []rune{'t'}})
+		// Press Right to "select all" — should only select filtered options
+		keyboard.SimulateKeyPress(keys.Right)
+		keyboard.SimulateKeyPress(keys.Tab)
+	}()
+
+	result, _ := pterm.DefaultInteractiveMultiselect.
+		WithOptions([]string{"alpha", "test-one", "beta", "test-two", "gamma", "test-three"}).
+		WithMaxHeight(10).
+		Show()
+	testza.AssertEqual(t, []string{"test-one", "test-two", "test-three"}, result)
+}
+
+func TestInteractiveMultiselectPrinter_Show_UnselectAllRespectsFilter(t *testing.T) {
+	go func() {
+		// Type "test" to filter options
+		keyboard.SimulateKeyPress(keys.Key{Code: keys.RuneKey, Runes: []rune{'t'}})
+		keyboard.SimulateKeyPress(keys.Key{Code: keys.RuneKey, Runes: []rune{'e'}})
+		keyboard.SimulateKeyPress(keys.Key{Code: keys.RuneKey, Runes: []rune{'s'}})
+		keyboard.SimulateKeyPress(keys.Key{Code: keys.RuneKey, Runes: []rune{'t'}})
+		// Press Left to "unselect all" — should only unselect filtered options, keeping "alpha"
+		keyboard.SimulateKeyPress(keys.Left)
+		keyboard.SimulateKeyPress(keys.Tab)
+	}()
+
+	result, _ := pterm.DefaultInteractiveMultiselect.
+		WithOptions([]string{"alpha", "test-one", "beta", "test-two"}).
+		WithDefaultOptions([]string{"alpha", "test-one", "test-two"}).
+		WithMaxHeight(10).
+		Show()
+	testza.AssertEqual(t, []string{"alpha"}, result)
+}
+
 func TestInteractiveMultiselectPrinter_WithDefaultText(t *testing.T) {
 	p := pterm.DefaultInteractiveMultiselect.WithDefaultText("default")
 	testza.AssertEqual(t, p.DefaultText, "default")


### PR DESCRIPTION
Fixes #761

## Problem

When using `InteractiveMultiselectPrinter` with filtering enabled, pressing Right arrow ("select all") selects **all** options in the original list, not just the currently filtered/visible options. Similarly, Left arrow ("unselect all") clears all selections regardless of the active filter.

## Before

- Type a filter string to narrow down options
- Press Right arrow → all options selected (ignoring filter)
- Press Left arrow → all selections cleared (ignoring filter)

## After

- Type a filter string to narrow down options
- Press Right arrow → only filtered options are selected; existing selections outside the filter are preserved
- Press Left arrow → only filtered options are unselected; existing selections outside the filter are preserved
- When no filter is active, behavior is unchanged

## Fix

- `keys.Right`: when `fuzzySearchString` is non-empty, iterate `fuzzySearchMatches` and add only unselected matches
- `keys.Left`: when `fuzzySearchString` is non-empty, iterate `fuzzySearchMatches` and deselect only selected matches using the existing `selectOption` toggle helper

## Validation

All existing tests pass. Two new regression tests added:
- `TestInteractiveMultiselectPrinter_Show_SelectAllRespectsFilter`
- `TestInteractiveMultiselectPrinter_Show_UnselectAllRespectsFilter`