### PR TITLE
fix: use cancellation signal in InteractiveContinuePrinter for proper Ctrl+C cleanup

### DIFF
--- a/interactive_continue_printer.go
+++ b/interactive_continue_printer.go
@@ -37,6 +37,7 @@ type InteractiveContinuePrinter struct {
 	Handles           []string
 	ShowShortHandles  bool
 	SuffixStyle       *Style
+	OnInterruptFunc   func()
 }
 
 // WithDefaultText sets the default text.
@@ -120,6 +121,11 @@ func (p InteractiveContinuePrinter) WithDelimiter(delimiter string) *Interactive
 //	result, _ := pterm.DefaultInteractiveContinue.Show("Do you want to apply the changes?")
 //	pterm.Println(result)
 func (p InteractiveContinuePrinter) Show(text ...string) (string, error) {
+	// should be the first defer statement to make sure it is executed last
+	// and all the needed cleanup can be done before
+	cancel, exit := internal.NewCancelationSignal(p.OnInterruptFunc)
+	defer exit()
+
 	var result string
 
 	if len(text) == 0 || text[0] == "" {
@@ -154,7 +160,7 @@ func (p InteractiveContinuePrinter) Show(text ...string) (string, error) {
 			result = p.Options[p.DefaultValueIndex]
 			return true, nil
 		case keys.CtrlC:
-			internal.Exit(1)
+			cancel()
 			return true, nil
 		}
 		return false, nil


### PR DESCRIPTION
Fixes #758

## Problem

`InteractiveContinuePrinter.Show()` calls `internal.Exit(1)` directly on Ctrl+C, which:
- Skips all deferred cleanup (keyboard listener `stopListener()` / `con.Reset()`)
- Leaves the terminal in raw mode
- Results in a broken prompt that requires `reset` to fix

All other interactive printers (`InteractiveSelectPrinter`, `InteractiveMultiselectPrinter`, `InteractiveTextInputPrinter`) were fixed in #383 to use `NewCancelationSignal`, but `InteractiveContinuePrinter` was missed.

## Fix

Apply the same cancellation signal pattern used by the other printers:
1. Add `OnInterruptFunc` field for custom interrupt handling (consistent API)
2. Replace `internal.Exit(1)` with `cancel()`
3. Defer `exit()` to ensure keyboard listener cleanup runs before exit

This ensures the terminal is properly restored to cooked mode before the process exits.