### PR TITLE
fix: respect fuzzy filter when selecting/deselecting all in InteractiveMultiselect

### DIFF
--- a/interactive_multiselect_printer.go
+++ b/interactive_multiselect_printer.go
@@ -258,16 +258,24 @@ func (p *InteractiveMultiselectPrinter) Show(text ...string) ([]string, error) {
 			area.Update(p.renderSelectMenu())
 
 		case keys.Left:
-			// Unselect all options
-			p.selectedOptions = []int{}
+			// Unselect all currently visible options.
+			// When a fuzzy filter is active this deselects only the matching
+			// subset; without a filter it deselects everything.
+			for _, match := range p.fuzzySearchMatches {
+				if p.isSelected(match) {
+					p.selectOption(match)
+				}
+			}
 			area.Update(p.renderSelectMenu())
 		case keys.Right:
-			// Select all options
-			p.selectedOptions = []int{}
-			for i := 0; i < len(p.Options); i++ {
-				p.selectedOptions = append(p.selectedOptions, i)
+			// Select all currently visible options.
+			// When a fuzzy filter is active this selects only the matching
+			// subset; without a filter it selects everything.
+			for _, match := range p.fuzzySearchMatches {
+				if !p.isSelected(match) {
+					p.selectOption(match)
+				}
 			}
-
 			area.Update(p.renderSelectMenu())
 
 		case keys.Up, keys.CtrlP:

--- a/interactive_multiselect_printer_test.go
+++ b/interactive_multiselect_printer_test.go
@@ -49,6 +49,49 @@ func TestInteractiveMultiselectPrinter_Show_AlternateNavigationKeys(t *testing.T
 	testza.AssertEqual(t, []string{"b", "c"}, result)
 }
 
+// TestInteractiveMultiselectPrinter_Show_SelectAll verifies that pressing Right
+// Arrow without a filter selects all options.
+func TestInteractiveMultiselectPrinter_Show_SelectAll(t *testing.T) {
+	go func() {
+		keyboard.SimulateKeyPress(keys.Right) // select all
+		keyboard.SimulateKeyPress(keys.Tab)   // confirm
+	}()
+
+	result, _ := pterm.DefaultInteractiveMultiselect.WithOptions([]string{"a", "b", "c"}).Show()
+	testza.AssertEqual(t, []string{"a", "b", "c"}, result)
+}
+
+// TestInteractiveMultiselectPrinter_Show_DeselectAll verifies that pressing Left
+// Arrow without a filter deselects all options.
+func TestInteractiveMultiselectPrinter_Show_DeselectAll(t *testing.T) {
+	go func() {
+		keyboard.SimulateKeyPress(keys.Right) // select all
+		keyboard.SimulateKeyPress(keys.Left)  // deselect all
+		keyboard.SimulateKeyPress(keys.Tab)   // confirm
+	}()
+
+	result, _ := pterm.DefaultInteractiveMultiselect.WithOptions([]string{"a", "b", "c"}).Show()
+	testza.AssertNil(t, result)
+}
+
+// TestInteractiveMultiselectPrinter_Show_SelectAllWithFilter verifies that
+// pressing Right Arrow when a fuzzy filter is active selects only the matching
+// options, not all options.  Regression test for issue #761.
+func TestInteractiveMultiselectPrinter_Show_SelectAllWithFilter(t *testing.T) {
+	go func() {
+		// Type "a" to filter — only option "a" matches
+		keyboard.SimulateKeyPress('a')
+		keyboard.SimulateKeyPress(keys.Right) // select all visible (only "a")
+		// Clear the filter to confirm all options are visible at submit
+		keyboard.SimulateKeyPress(keys.Backspace)
+		keyboard.SimulateKeyPress(keys.Tab) // confirm
+	}()
+
+	result, _ := pterm.DefaultInteractiveMultiselect.WithOptions([]string{"a", "b", "c"}).Show()
+	// Only "a" should be selected; "b" and "c" were not visible when Right was pressed.
+	testza.AssertEqual(t, []string{"a"}, result)
+}
+
 func TestInteractiveMultiselectPrinter_WithDefaultText(t *testing.T) {
 	p := pterm.DefaultInteractiveMultiselect.WithDefaultText("default")
 	testza.AssertEqual(t, p.DefaultText, "default")


### PR DESCRIPTION
## Problem

When typing a search filter in \`InteractiveMultiselectPrinter\` and pressing **Right Arrow** (select all), all options get selected — not just the ones visible in the filtered list.

**Repro:**
1. Create multiselect with options \`["opt1", "test1", "test2", "test3"]\`
2. Type \`test\` to filter — only 3 matching options shown
3. Press Right Arrow to select all
4. Clear the filter — all 4 options are selected instead of only the 3 that matched

Similarly, **Left Arrow** (deselect all) always cleared the entire selection regardless of filter.

Fixes #761.

## Root cause

Both handlers iterated \`p.Options\` (all options) instead of \`p.fuzzySearchMatches\` (the currently visible subset):

```go
// before — ignores active filter
case keys.Right:
    p.selectedOptions = []int{}
    for i := 0; i < len(p.Options); i++ {  // BUG: all options, not filtered
        p.selectedOptions = append(p.selectedOptions, i)
    }
```

## Fix

Iterate \`p.fuzzySearchMatches\` and use the existing \`selectOption\`/\`isSelected\` helpers. When no filter is active, \`fuzzySearchMatches == Options\`, so unfiltered behaviour is unchanged.

## Tests

Three new tests:
- \`Show_SelectAll\`: Right Arrow without filter selects all
- \`Show_DeselectAll\`: Right then Left returns to empty selection
- \`Show_SelectAllWithFilter\`: Right Arrow after typing \`a\` selects only \`a\`, not \`b\` or \`c\`

All existing tests pass.