### PR TITLE
fix: BasicTextPrinter.Sprintln appends two newlines instead of one

### DIFF
--- a/basic_text_printer.go
+++ b/basic_text_printer.go
@@ -42,7 +42,7 @@ func (p BasicTextPrinter) Sprint(a ...any) string {
 // Spaces are always added between operands and a newline is appended.
 func (p BasicTextPrinter) Sprintln(a ...any) string {
 	str := fmt.Sprintln(a...)
-	return Sprintln(p.Sprint(str))
+	return p.Sprint(str)
 }
 
 // Sprintf formats according to a format specifier and returns the resulting string.

--- a/basic_text_printer_test.go
+++ b/basic_text_printer_test.go
@@ -98,6 +98,11 @@ func TestBasicTextPrinterPrintMethods(t *testing.T) {
 	})
 }
 
+func TestBasicTextPrinterSprintlnSingleNewline(t *testing.T) {
+	result := pterm.DefaultBasicText.Sprintln("hello")
+	testza.AssertEqual(t, "hello\n", result)
+}
+
 func TestBasicTextPrinter_WithStyle(t *testing.T) {
 	s := pterm.NewStyle(pterm.FgRed, pterm.BgBlue, pterm.Bold)
 	p := pterm.BasicTextPrinter{}


### PR DESCRIPTION
Fixes #762.

`BasicTextPrinter.Sprintln` was calling `fmt.Sprintln` to format the input (which appends `\n`), then passing the result to the package-level `Sprintln`. That second call runs `fmt.Sprintln` again on a string that already ends in `\n`, so you get `\n\n` instead of `\n`.

```go
// before
func (p BasicTextPrinter) Sprintln(a ...any) string {
    str := fmt.Sprintln(a...)
    return Sprintln(p.Sprint(str))  // Sprintln calls fmt.Sprintln again -> double \n
}

// after
func (p BasicTextPrinter) Sprintln(a ...any) string {
    str := fmt.Sprintln(a...)
    return p.Sprint(str)  // just apply styling, newline already present
}
```

Added a regression test that asserts `DefaultBasicText.Sprintln("hello") == "hello\n"`.