### PR TITLE
fix: InteractiveMultiselect right arrow selects only filtered options

### DIFF
--- a/interactive_multiselect_printer.go
+++ b/interactive_multiselect_printer.go
@@ -262,10 +262,17 @@ func (p *InteractiveMultiselectPrinter) Show(text ...string) ([]string, error) {
 			p.selectedOptions = []int{}
 			area.Update(p.renderSelectMenu())
 		case keys.Right:
-			// Select all options
-			p.selectedOptions = []int{}
-			for i := 0; i < len(p.Options); i++ {
-				p.selectedOptions = append(p.selectedOptions, i)
+			// Select every option that's currently visible. With no filter
+			// active this is all options; with a filter it's just the matches.
+			for _, match := range p.fuzzySearchMatches {
+				if p.isSelected(match) {
+					continue
+				}
+				idx := p.findOptionByText(match)
+				if idx < 0 {
+					continue
+				}
+				p.selectedOptions = append(p.selectedOptions, idx)
 			}
 
 			area.Update(p.renderSelectMenu())

--- a/interactive_multiselect_printer_test.go
+++ b/interactive_multiselect_printer_test.go
@@ -49,6 +49,28 @@ func TestInteractiveMultiselectPrinter_Show_AlternateNavigationKeys(t *testing.T
 	testza.AssertEqual(t, []string{"b", "c"}, result)
 }
 
+func TestInteractiveMultiselectPrinter_Show_SelectAllNoFilter(t *testing.T) {
+	go func() {
+		keyboard.SimulateKeyPress(keys.Right)
+		keyboard.SimulateKeyPress(keys.Tab)
+	}()
+
+	result, _ := pterm.DefaultInteractiveMultiselect.WithOptions([]string{"a", "b", "c"}).Show()
+	testza.AssertEqual(t, []string{"a", "b", "c"}, result)
+}
+
+func TestInteractiveMultiselectPrinter_Show_SelectAllRespectsFilter(t *testing.T) {
+	go func() {
+		keyboard.SimulateKeyPress('b')
+		keyboard.SimulateKeyPress(keys.Right)
+		keyboard.SimulateKeyPress(keys.Backspace)
+		keyboard.SimulateKeyPress(keys.Tab)
+	}()
+
+	result, _ := pterm.DefaultInteractiveMultiselect.WithOptions([]string{"apple", "banana", "cherry", "blueberry"}).Show()
+	testza.AssertEqual(t, []string{"banana", "blueberry"}, result)
+}
+
 func TestInteractiveMultiselectPrinter_WithDefaultText(t *testing.T) {
 	p := pterm.DefaultInteractiveMultiselect.WithDefaultText("default")
 	testza.AssertEqual(t, p.DefaultText, "default")


### PR DESCRIPTION
Closes #761.

The right-arrow "select all" handler in the interactive multiselect was looping over `p.Options` directly, so even with a filter active it would still select every original option. So if you filtered 100 items down to 5 matches and hit right-arrow expecting just those 5, you'd actually get all 100.

Switched the loop to walk `p.fuzzySearchMatches`, which is the slice of currently visible options. When no filter is active that slice equals `p.Options`, so the no-filter case (and the existing behavior) is unchanged. Also added an already-selected check so previous selections from other filter views don't get duplicated or wiped out.

## Test plan

```
go test -run TestInteractiveMultiselectPrinter_Show ./...
```

Added two new tests:
- `TestInteractiveMultiselectPrinter_Show_SelectAllNoFilter` — regression for the no-filter case
- `TestInteractiveMultiselectPrinter_Show_SelectAllRespectsFilter` — filter 4 items down to 2, right-arrow, confirm; only the 2 filtered items are returned