### PR TITLE
fix(spinner): remove data race on SpinnerPrinter IsActive and Text

### DIFF
--- a/spinner_printer.go
+++ b/spinner_printer.go
@@ -3,6 +3,8 @@ package pterm
 import (
 	"io"
 	"os"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pterm/pterm/internal"
@@ -46,6 +48,14 @@ type SpinnerPrinter struct {
 
 	IsActive bool
 
+	// active mirrors IsActive but is safe to read concurrently with Stop.
+	// The animation goroutine reads it instead of IsActive to avoid the data
+	// race that -race flags between the goroutine and Stop().
+	active atomic.Bool
+
+	// mu guards Text and currentSequence so UpdateText can safely run while
+	// the animation goroutine is reading them.
+	mu              sync.Mutex
 	startedAt       time.Time
 	currentSequence string
 
@@ -136,17 +146,21 @@ func (s *SpinnerPrinter) SetStartedAt(t time.Time) {
 // UpdateText updates the message of the active SpinnerPrinter.
 // Can be used live.
 func (s *SpinnerPrinter) UpdateText(text string) {
+	s.mu.Lock()
 	s.Text = text
+	currentSequence := s.currentSequence
+	s.mu.Unlock()
 	if !RawOutput {
-		Fprinto(s.Writer, "\033[K"+s.Style.Sprint(s.currentSequence)+" "+s.MessageStyle.Sprint(s.Text))
+		Fprinto(s.Writer, "\033[K"+s.Style.Sprint(currentSequence)+" "+s.MessageStyle.Sprint(text))
 	} else {
-		Fprintln(s.Writer, s.Text)
+		Fprintln(s.Writer, text)
 	}
 }
 
 // Start the SpinnerPrinter.
 func (s SpinnerPrinter) Start(text ...any) (*SpinnerPrinter, error) {
 	s.IsActive = true
+	s.active.Store(true)
 	s.startedAt = time.Now()
 	activeSpinnerPrinters = append(activeSpinnerPrinters, &s)
 
@@ -154,41 +168,47 @@ func (s SpinnerPrinter) Start(text ...any) (*SpinnerPrinter, error) {
 		s.Text = Sprint(text...)
 	}
 
+	sp := &s
 	go func() {
-		for s.IsActive {
-			for _, seq := range s.Sequence {
-				if !s.IsActive {
+		for sp.active.Load() {
+			for _, seq := range sp.Sequence {
+				if !sp.active.Load() {
 					continue
 				}
 
 				if RawOutput {
-					time.Sleep(s.Delay)
+					time.Sleep(sp.Delay)
 					continue
 				}
 
 				var timer string
-				if s.ShowTimer {
-					timer = " (" + time.Since(s.startedAt).Round(s.TimerRoundingFactor).String() + ")"
+				if sp.ShowTimer {
+					timer = " (" + time.Since(sp.startedAt).Round(sp.TimerRoundingFactor).String() + ")"
 				}
 
-				Fprinto(s.Writer, s.Style.Sprint(seq)+" "+s.MessageStyle.Sprint(s.Text)+s.TimerStyle.Sprint(timer))
-				s.currentSequence = seq
-				time.Sleep(s.Delay)
+				sp.mu.Lock()
+				text := sp.Text
+				sp.currentSequence = seq
+				sp.mu.Unlock()
+
+				Fprinto(sp.Writer, sp.Style.Sprint(seq)+" "+sp.MessageStyle.Sprint(text)+sp.TimerStyle.Sprint(timer))
+				time.Sleep(sp.Delay)
 			}
 		}
 	}()
 
-	return &s, nil
+	return sp, nil
 }
 
 // Stop terminates the SpinnerPrinter immediately.
 // The SpinnerPrinter will not resolve into anything.
 func (s *SpinnerPrinter) Stop() error {
-	if !s.IsActive {
+	if !s.active.Load() {
 		return nil
 	}
 
 	s.IsActive = false
+	s.active.Store(false)
 
 	if RawOutput {
 		return nil


### PR DESCRIPTION
Closes #482.

The animation goroutine in `Start()` reads `s.IsActive` in a tight loop while `Stop()` writes the same field from the caller's goroutine, which `-race` flags. `UpdateText()` has the same problem on `s.Text` and `s.currentSequence` (goroutine reads them, UpdateText writes).

Two changes:

- Added an internal `atomic.Bool` mirroring `IsActive`. The goroutine reads the atomic, Stop writes both. The public `IsActive` field stays where it is so existing external code keeps working, it's just no longer the source of truth for the goroutine.
- Added a mutex protecting `Text` and `currentSequence` so `UpdateText` and the goroutine can coordinate without racing.

There's still a separate pre-existing race in the test harness (`testza` setup writes to the global `DefaultOutput` from one goroutine while it gets read in another), so the full `-race` run still flags those, but they're independent of the SpinnerPrinter and #447 already takes a swing at them. The SpinnerPrinter itself is clean now.

## Test plan

```
go test ./...
```

All spinner tests still pass. The fix doesn't change observable behavior outside of removing the races.