### PR TITLE
fix(table): use unicode vertical bar in default Separator

### DIFF
--- a/table_printer.go
+++ b/table_printer.go
@@ -14,7 +14,7 @@ var DefaultTable = TablePrinter{
 	HeaderStyle:             &ThemeDefault.TableHeaderStyle,
 	HeaderRowSeparator:      "",
 	HeaderRowSeparatorStyle: &ThemeDefault.TableSeparatorStyle,
-	Separator:               " | ",
+	Separator:               " │ ",
 	SeparatorStyle:          &ThemeDefault.TableSeparatorStyle,
 	RowSeparator:            "",
 	RowSeparatorStyle:       &ThemeDefault.TableSeparatorStyle,


### PR DESCRIPTION
Mirror of #780 for the table printer. Switches the default `Separator` from \" | \" to \" │ \" so boxed tables don't mix ASCII pipes with the Unicode box-drawing characters BoxPrinter already uses for the surrounding frame.

Before:
\`\`\`
┌──────────────────────────┐
| col1 | col2 | col3       |
└──────────────────────────┘
\`\`\`

After:
\`\`\`
┌──────────────────────────┐
│ col1 │ col2 │ col3       │
└──────────────────────────┘
\`\`\`

Anyone who'd been customizing \`Separator\` still gets exactly what they set. Closes #755.