### PR TITLE
fix(prefix): indent multi-line messages by display width for wide prefixes

### DIFF
--- a/prefix_printer.go
+++ b/prefix_printer.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/mattn/go-runewidth"
+
 	"github.com/pterm/pterm/internal"
 )
 
@@ -202,7 +204,7 @@ func (p *PrefixPrinter) Sprint(a ...any) string {
 			ret.WriteString(p.MessageStyle.Sprint(m))
 		} else {
 			ret.WriteByte('\n')
-			ret.WriteString(p.Prefix.Style.Sprint(strings.Repeat(" ", len([]rune(p.Prefix.Text))+2)))
+			ret.WriteString(p.Prefix.Style.Sprint(strings.Repeat(" ", runewidth.StringWidth(p.Prefix.Text)+2)))
 			ret.WriteByte(' ')
 			ret.WriteString(p.MessageStyle.Sprint(m))
 		}

--- a/prefix_printer_test.go
+++ b/prefix_printer_test.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/MarvinJWendt/testza"
+	"github.com/mattn/go-runewidth"
 
 	"github.com/pterm/pterm"
 )
@@ -453,6 +455,40 @@ func TestPrefixPrinter_GetWriter(t *testing.T) {
 			testza.AssertEqual(t, os.Stderr, p.GetWriter())
 			p2 := p.WithWriter(os.Stdout)
 			testza.AssertEqual(t, os.Stdout, p2.GetWriter())
+		})
+	}
+}
+
+// TestPrefixPrinter_MultilineWideRuneIndent verifies that continuation lines of
+// a multi-line message are indented by the display width of the prefix, not by
+// its rune count. With wide (East Asian) characters in the prefix the two
+// differ, so the message text on the second line must still line up with the
+// message text on the first line.
+func TestPrefixPrinter_MultilineWideRuneIndent(t *testing.T) {
+	pterm.EnableStyling()
+
+	tests := []struct {
+		name   string
+		prefix string
+	}{
+		{name: "ascii", prefix: "INFO"},
+		{name: "wide", prefix: "情報"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := pterm.PrefixPrinter{
+				MessageStyle: pterm.NewStyle(),
+				Prefix:       pterm.Prefix{Text: tt.prefix, Style: pterm.NewStyle()},
+			}
+
+			out := pterm.RemoveColorFromString(p.Sprint("first\nsecond"))
+			lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+			testza.AssertEqual(t, 2, len(lines))
+
+			col1 := runewidth.StringWidth(lines[0][:strings.Index(lines[0], "first")])
+			col2 := runewidth.StringWidth(lines[1][:strings.Index(lines[1], "second")])
+			testza.AssertEqual(t, col1, col2)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #797

Multi-line messages from a `PrefixPrinter` indent their continuation lines so
they line up under the message on the first line. The indent width was taken
from the rune count of the prefix text:

```go
strings.Repeat(" ", len([]rune(p.Prefix.Text))+2)
```

The first line's prefix is rendered by `GetFormattedPrefix` as
`" " + Text + " "`, so its on-screen width is the display width of the text.
Rune count and display width differ for East Asian wide characters (`情報` is
2 runes but 4 columns), which left the continuation lines shifted left.

This switches the indent to `runewidth.StringWidth`, the same width helper the
rest of the package already uses for alignment (`box_printer.go`,
`center_printer.go`, `header_printer.go`, `internal/longest_line.go`).
`go-runewidth` is already a direct dependency.

For ASCII prefixes rune count equals display width, so the output is
unchanged. Added a test that checks the message column on the second line
matches the first line, for both an ASCII and a wide prefix.
