### PR TITLE
fix: correct alignment of the cursor in multi-line text input and clear the input using Ctrl+L

### DIFF
--- a/interactive_textinput_printer.go
+++ b/interactive_textinput_printer.go
@@ -107,7 +107,9 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 	}
 
 	if p.DefaultValue != "" {
-		p.input = append(p.input, p.DefaultValue)
+		p.input = append(p.input, strings.Split(p.DefaultValue, "\n")...)
+		// init cursor position
+		p.cursorYPos += len(p.input) - 1
 		p.updateArea(&area)
 	}
 
@@ -189,7 +191,6 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 
 		case keys.Delete:
 			if !p.startedTyping {
-				p.input = []string{""}
 				p.startedTyping = true
 
 				return false, nil
@@ -214,7 +215,6 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 			}
 
 			if !p.startedTyping {
-				p.input = []string{""}
 				p.startedTyping = true
 			}
 
@@ -230,7 +230,6 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 			}
 
 			if !p.startedTyping {
-				p.input = []string{""}
 				p.startedTyping = true
 			}
 
@@ -239,6 +238,14 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 
 				p.cursorYPos--
 			}
+
+		case keys.CtrlL:
+			if !p.startedTyping {
+				p.startedTyping = true
+			}
+			// reset input and cusorYPos
+			p.cursorYPos = 0
+			p.input = []string{""}
 		}
 
 		if internal.GetStringMaxWidth(p.input[p.cursorYPos]) > 0 {

--- a/interactive_textinput_printer_test.go
+++ b/interactive_textinput_printer_test.go
@@ -106,8 +106,8 @@ func TestInteractiveTextInputPrinter_DefaultValue(t *testing.T) {
 		assert.Equal(t, "abcd", result)
 	})
 
-	t.Run("delete discards the default value", func(t *testing.T) {
-		simulateKeys(t, keys.Delete, 'x', keys.Enter)
+	t.Run("ctrl+L discards the default value", func(t *testing.T) {
+		simulateKeys(t, keys.CtrlL, 'x', keys.Enter)
 
 		result := showTextInput(t, pterm.DefaultInteractiveTextInput.WithDefaultValue("abc"))
 


### PR DESCRIPTION

Fixes #802

Problem
---
1. When a `DefaultValue` is present, `p.input` is set to `append(p.input, p.DefaultValue)`, meaning that `len(p.input)` is always initialised to `1`, rather than being determined by the number of lines in the `DefaultValue` text
2. `p.cursorYPos` defaults to 0, and its range is `[0, len(p.input)-1]`.
3. When `Up`, `Down` or `Delete` are pressed for the first time, `p.input` is set to `[]string{‘’}`.

Fix
---
1. Initialise `p.input` as `append(p.input, strings.Split(p.DefaultValue, ‘\n’)...)`
2. Initialise `p.cursorYPos` to `len(p.input)-1`, i.e. the end of the text
3. Remove the modification to `p.input` upon the first press of `Up`, `Down` or `Delete`. Add `Ctrl+L` to reset `p.input` and `p.cursorYPos`

Before
---
1. When an InteractiveTextInputPrinter in multi-line mode contains a multi-line DefaultValue, the cursor is displayed out of position.
2. Pressing `Up`, `Down` or `Delete` for the first time clears the text, which makes it inconvenient to edit the input.

After
---
The cursor is correctly positioned at the end of the text
Pressing `Ctrl+L` clears the input
Pressing `Up`, `Down` or `Delete` performs their respective functions