### PR TITLE
fix: interactive repeat line and correct alignment of the cursor in text input

### DIFF
--- a/interactive.go
+++ b/interactive.go
@@ -12,15 +12,19 @@ func getMaxW(s string) int {
 	return internal.GetStringMaxWidth(s)
 }
 
-// fit the text for terminal width
-func textFitWidth(text string) string {
-	return strings.Join(linesFitWidth(strings.Split(text, "\n")), "\n")
+// fit the text for terminal width,offset to the right
+func textFitWidth(text string, offset ...int) string {
+	return strings.Join(linesFitWidth(strings.Split(text, "\n"), offset...), "\n")
 }
 
-// fit the []string for terminal width
-func linesFitWidth(ss []string) []string {
+// fit the []string for terminal width,offset to the right
+func linesFitWidth(ss []string, offset ...int) []string {
 	w := max(GetTerminalWidth()-1, 1)
-	if getMaxW(strings.Join(ss, "\n")) >= w {
+	firstLineOffset := 0
+	if len(offset) > 0 {
+		firstLineOffset = offset[0]
+	}
+	if getMaxW(strings.Join(ss, "\n")) >= w || getMaxW(ss[0])+firstLineOffset >= w {
 		// find the last index that GetStringWidth(s[:index])<=width
 		findIndex := func(s string, width int) int {
 			l, r := 0, len(s)+1
@@ -36,16 +40,26 @@ func linesFitWidth(ss []string) []string {
 		}
 
 		buffer := make([]string, 0)
-		for _, s := range ss {
+		for k, s := range ss {
+			if k == 0 {
+				fw := w - firstLineOffset
+				if getMaxW(s) <= fw {
+					buffer = append(buffer, s)
+					continue
+				}
+				// Split First Row
+				i := indexSplitAtByte(s, findIndex(s, fw))
+				buffer = append(buffer, s[:i])
+				s = s[i:]
+			}
 			if getMaxW(s) <= w {
 				buffer = append(buffer, s)
 				continue
 			}
 			for len(s) > 0 {
-				i := countValidBeginRunes(s[:findIndex(s, w)])
-				front, end := string([]rune(s)[:i]), string([]rune(s)[i:])
-				buffer = append(buffer, front)
-				s = end
+				i := indexSplitAtByte(s, findIndex(s, w))
+				buffer = append(buffer, s[:i])
+				s = s[i:]
 			}
 		}
 		return buffer
@@ -54,20 +68,23 @@ func linesFitWidth(ss []string) []string {
 	return ss
 }
 
-// count runes maybe invalid bytes at the end
-func countValidBeginRunes(s string) int {
-	if s == "" {
-		return 0
+// Returns a corrected index that,
+// when a string is split into two strings, puts the broken character into the next string
+func indexSplitAtByte(s string, i int) int {
+	if i < 0 {
+		i = 0
 	}
-	// Remove all invalid bytes at the end
-	for {
-		r, size := utf8.DecodeLastRuneInString(s)
-		if r != utf8.RuneError || size != 1 {
-			break
-		}
-		s = s[:len(s)-1]
+	if i > len(s) {
+		i = len(s)
 	}
-	return utf8.RuneCountInString(s)
+	if i == 0 || i == len(s) || utf8.RuneStart(s[i]) {
+		return i
+	}
+	// Go back to the start byte of the current character
+	for i > 0 && !utf8.RuneStart(s[i]) {
+		i--
+	}
+	return i
 }
 
 // this create a [time.Ticker] that

--- a/interactive.go
+++ b/interactive.go
@@ -1,0 +1,79 @@
+package pterm
+
+import (
+	"os"
+	"strings"
+
+	"github.com/pterm/pterm/internal"
+	"golang.org/x/term"
+)
+
+func getWidth(s string) int {
+	return min(GetTerminalWidth(), internal.GetStringMaxWidth(s))
+}
+func textFitWidth(text string) string {
+	getWidth := internal.GetStringWidth
+	w := GetTerminalWidth()
+	if internal.GetStringMaxWidth(text) >= w {
+		// find the last index that GetStringWidth(s[:index])<=width
+		findIndex := func(s string, width int) int {
+			l, r := 0, len(s)+1
+			for l+1 < r {
+				mid := (l + r) >> 1
+				if getWidth(s[:mid]) <= width {
+					l = mid
+				} else {
+					r = mid
+				}
+			}
+			return l
+		}
+		buffer := make([]string, 0)
+		for _, s := range strings.Split(text, "\n") {
+			if getWidth(s) <= w {
+				buffer = append(buffer, s)
+				continue
+			}
+			for len(s) > 0 {
+				i := findIndex(s, w)
+				buffer = append(buffer, s[:i])
+				s = s[i:]
+			}
+		}
+		text = strings.Join(buffer, "\n")
+	}
+	return text
+}
+func inputFitWidth(ss []string) []string {
+	getWidth := internal.GetStringWidth
+	w, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err == nil && internal.GetStringMaxWidth(strings.Join(ss, "\n")) > w {
+		// find the last index that GetStringWidth(s[:index])<=width
+		findIndex := func(s string, width int) int {
+			l, r := 0, len(s)+1
+			for l+1 < r {
+				mid := (l + r) >> 1
+				if getWidth(s[:mid]) <= width {
+					l = mid
+				} else {
+					r = mid
+				}
+			}
+			return l
+		}
+		buffer := make([]string, 0)
+		for _, s := range ss {
+			if getWidth(s) <= w {
+				buffer = append(buffer, s)
+				continue
+			}
+			for len(s) > 0 {
+				i := findIndex(s, w)
+				buffer = append(buffer, s[:i])
+				s = s[i:]
+			}
+		}
+		return buffer
+	}
+	return ss
+}

--- a/interactive.go
+++ b/interactive.go
@@ -6,47 +6,16 @@ import (
 	"github.com/pterm/pterm/internal"
 )
 
-func getWidth(s string) int {
-	return min(GetTerminalWidth(), internal.GetStringMaxWidth(s))
-}
 func getMaxW(s string) int {
 	return internal.GetStringMaxWidth(s)
 }
 
+// fit the text for terminal width
 func textFitWidth(text string) string {
-	getWidth := internal.GetStringWidth
-	w := GetTerminalWidth()
-	if internal.GetStringMaxWidth(text) > w {
-		// find the last index that GetStringWidth(s[:index])<=width
-		findIndex := func(s string, width int) int {
-			l, r := 0, len(s)+1
-			for l+1 < r {
-				mid := (l + r) >> 1
-				if getWidth(s[:mid]) <= width {
-					l = mid
-				} else {
-					r = mid
-				}
-			}
-			return l
-		}
-		buffer := make([]string, 0)
-		for _, s := range strings.Split(text, "\n") {
-			if getWidth(s) <= w {
-				buffer = append(buffer, s)
-				continue
-			}
-			for len(s) > 0 {
-				i := findIndex(s, w)
-				buffer = append(buffer, s[:i])
-				s = s[i:]
-			}
-		}
-		text = strings.Join(buffer, "\n")
-	}
-	return text
+	return strings.Join(linesFitWidth(strings.Split(text, "\n")), "\n")
 }
-func inputFitWidth(ss []string) []string {
+
+func linesFitWidth(ss []string) []string {
 	getWidth := internal.GetStringWidth
 	w := GetTerminalWidth()
 	if internal.GetStringMaxWidth(strings.Join(ss, "\n")) > w {
@@ -79,4 +48,35 @@ func inputFitWidth(ss []string) []string {
 	}
 
 	return ss
+}
+
+// returns the coords typed [][2]int that index is the actual line number in terminal
+// areaInput := [inputFitWidth](p.input)
+// if y,x is the actual coords in terminal,y ∈ [0,len(areaInput)), x ∈[-len(areaInput[y]),0]
+// p.cursorYPos,p.cursorXPos:=coords[y][0],coords[y][1]+x
+func inputCoords(ss []string) [][2]int {
+	coords := [][2]int{}
+	for py, s := range ss {
+		px := -getMaxW(s)
+		for _, line := range linesFitWidth([]string{s}) {
+			px += getMaxW(line)
+			coords = append(coords, [2]int{py, px})
+		}
+	}
+	return coords
+}
+
+// returns the coords in logic input
+func logicYX(ay, ax int, coords [][2]int) (int, int) {
+	return coords[ay][0], coords[ay][1] + ax
+}
+
+// returns actual coord in terminal,if not returns itself
+func actualYX(py, px int, coords [][2]int) (int, int) {
+	for ay, c := range coords {
+		if c[0] == py && c[1] >= px {
+			return ay, px - c[1]
+		}
+	}
+	return py, px
 }

--- a/interactive.go
+++ b/interactive.go
@@ -1,20 +1,22 @@
 package pterm
 
 import (
-	"os"
 	"strings"
 
 	"github.com/pterm/pterm/internal"
-	"golang.org/x/term"
 )
 
 func getWidth(s string) int {
 	return min(GetTerminalWidth(), internal.GetStringMaxWidth(s))
 }
+func getMaxW(s string) int {
+	return internal.GetStringMaxWidth(s)
+}
+
 func textFitWidth(text string) string {
 	getWidth := internal.GetStringWidth
 	w := GetTerminalWidth()
-	if internal.GetStringMaxWidth(text) >= w {
+	if internal.GetStringMaxWidth(text) > w {
 		// find the last index that GetStringWidth(s[:index])<=width
 		findIndex := func(s string, width int) int {
 			l, r := 0, len(s)+1
@@ -46,8 +48,8 @@ func textFitWidth(text string) string {
 }
 func inputFitWidth(ss []string) []string {
 	getWidth := internal.GetStringWidth
-	w, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err == nil && internal.GetStringMaxWidth(strings.Join(ss, "\n")) > w {
+	w := GetTerminalWidth()
+	if internal.GetStringMaxWidth(strings.Join(ss, "\n")) > w {
 		// find the last index that GetStringWidth(s[:index])<=width
 		findIndex := func(s string, width int) int {
 			l, r := 0, len(s)+1
@@ -75,5 +77,6 @@ func inputFitWidth(ss []string) []string {
 		}
 		return buffer
 	}
+
 	return ss
 }

--- a/interactive.go
+++ b/interactive.go
@@ -35,21 +35,6 @@ func linesFitWidth(ss []string) []string {
 			return l
 		}
 
-		// count runes maybe invalid bytes at the end
-		countValidRunes := func(s string) int {
-			if s == "" {
-				return 0
-			}
-			// Remove all invalid bytes at the end
-			for {
-				r, size := utf8.DecodeLastRuneInString(s)
-				if r != utf8.RuneError || size != 1 {
-					break
-				}
-				s = s[:len(s)-1]
-			}
-			return utf8.RuneCountInString(s)
-		}
 		buffer := make([]string, 0)
 		for _, s := range ss {
 			if getMaxW(s) <= w {
@@ -57,7 +42,7 @@ func linesFitWidth(ss []string) []string {
 				continue
 			}
 			for len(s) > 0 {
-				i := countValidRunes(s[:findIndex(s, w)])
+				i := countValidBeginRunes(s[:findIndex(s, w)])
 				front, end := string([]rune(s)[:i]), string([]rune(s)[i:])
 				buffer = append(buffer, front)
 				s = end
@@ -67,6 +52,22 @@ func linesFitWidth(ss []string) []string {
 	}
 
 	return ss
+}
+
+// count runes maybe invalid bytes at the end
+func countValidBeginRunes(s string) int {
+	if s == "" {
+		return 0
+	}
+	// Remove all invalid bytes at the end
+	for {
+		r, size := utf8.DecodeLastRuneInString(s)
+		if r != utf8.RuneError || size != 1 {
+			break
+		}
+		s = s[:len(s)-1]
+	}
+	return utf8.RuneCountInString(s)
 }
 
 // this create a [time.Ticker] that

--- a/interactive.go
+++ b/interactive.go
@@ -51,6 +51,7 @@ func linesFitWidth(ss []string) []string {
 }
 
 // returns the coords typed [][2]int that index is the actual line number in terminal
+// the param ss should be the []string that fit the terminal width
 // areaInput := [inputFitWidth](p.input)
 // if y,x is the actual coords in terminal,y ∈ [0,len(areaInput)), x ∈[-len(areaInput[y]),0]
 // p.cursorYPos,p.cursorXPos:=coords[y][0],coords[y][1]+x

--- a/interactive.go
+++ b/interactive.go
@@ -2,7 +2,6 @@ package pterm
 
 import (
 	"strings"
-	"time"
 	"unicode/utf8"
 
 	"github.com/pterm/pterm/internal"
@@ -85,25 +84,4 @@ func indexSplitAtByte(s string, i int) int {
 		i--
 	}
 	return i
-}
-
-// this create a [time.Ticker] that
-// call the onChange(width)
-// when the terminal's width changed
-func watchWidth(done <-chan struct{}, interval time.Duration, onChange func(w int)) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	last := GetTerminalWidth()
-	for {
-		select {
-		case <-done:
-			return
-		case <-ticker.C:
-			if w := GetTerminalWidth(); w != last {
-				last = w
-				onChange(w)
-			}
-		}
-	}
 }

--- a/interactive.go
+++ b/interactive.go
@@ -2,6 +2,7 @@ package pterm
 
 import (
 	"strings"
+	"time"
 
 	"github.com/pterm/pterm/internal"
 )
@@ -15,16 +16,17 @@ func textFitWidth(text string) string {
 	return strings.Join(linesFitWidth(strings.Split(text, "\n")), "\n")
 }
 
+// fit the []string for terminal width
 func linesFitWidth(ss []string) []string {
-	getWidth := internal.GetStringWidth
-	w := GetTerminalWidth()
-	if internal.GetStringMaxWidth(strings.Join(ss, "\n")) > w {
+	w := max(GetTerminalWidth()-1, 1)
+	if internal.GetStringMaxWidth(strings.Join(ss, "\n")) >= w {
 		// find the last index that GetStringWidth(s[:index])<=width
 		findIndex := func(s string, width int) int {
 			l, r := 0, len(s)+1
 			for l+1 < r {
 				mid := (l + r) >> 1
-				if getWidth(s[:mid]) <= width {
+				// if getMaxW(string([]rune(s)[:mid])) <= width {
+				if getMaxW(s[:mid]) <= width {
 					l = mid
 				} else {
 					r = mid
@@ -34,12 +36,14 @@ func linesFitWidth(ss []string) []string {
 		}
 		buffer := make([]string, 0)
 		for _, s := range ss {
-			if getWidth(s) <= w {
+			if getMaxW(s) <= w {
 				buffer = append(buffer, s)
 				continue
 			}
 			for len(s) > 0 {
 				i := findIndex(s, w)
+				// buffer = append(buffer, string([]rune(s)[:i]))
+				// s = string([]rune(s)[i:])
 				buffer = append(buffer, s[:i])
 				s = s[i:]
 			}
@@ -50,34 +54,23 @@ func linesFitWidth(ss []string) []string {
 	return ss
 }
 
-// returns the coords typed [][2]int that index is the actual line number in terminal
-// the param ss should be the []string that fit the terminal width
-// areaInput := [inputFitWidth](p.input)
-// if y,x is the actual coords in terminal,y ∈ [0,len(areaInput)), x ∈[-len(areaInput[y]),0]
-// p.cursorYPos,p.cursorXPos:=coords[y][0],coords[y][1]+x
-func inputCoords(ss []string) [][2]int {
-	coords := [][2]int{}
-	for py, s := range ss {
-		px := -getMaxW(s)
-		for _, line := range linesFitWidth([]string{s}) {
-			px += getMaxW(line)
-			coords = append(coords, [2]int{py, px})
+// this create a [time.Ticker] that
+// call the onChange(width)
+// when the terminal's width changed
+func watchWidth(done <-chan struct{}, interval time.Duration, onChange func(w int)) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	last := GetTerminalWidth()
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			if w := GetTerminalWidth(); w != last {
+				last = w
+				onChange(w)
+			}
 		}
 	}
-	return coords
-}
-
-// returns the coords in logic input
-func logicYX(ay, ax int, coords [][2]int) (int, int) {
-	return coords[ay][0], coords[ay][1] + ax
-}
-
-// returns actual coord in terminal,if not returns itself
-func actualYX(py, px int, coords [][2]int) (int, int) {
-	for ay, c := range coords {
-		if c[0] == py && c[1] >= px {
-			return ay, px - c[1]
-		}
-	}
-	return py, px
 }

--- a/interactive.go
+++ b/interactive.go
@@ -3,6 +3,7 @@ package pterm
 import (
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/pterm/pterm/internal"
 )
@@ -19,13 +20,12 @@ func textFitWidth(text string) string {
 // fit the []string for terminal width
 func linesFitWidth(ss []string) []string {
 	w := max(GetTerminalWidth()-1, 1)
-	if internal.GetStringMaxWidth(strings.Join(ss, "\n")) >= w {
+	if getMaxW(strings.Join(ss, "\n")) >= w {
 		// find the last index that GetStringWidth(s[:index])<=width
 		findIndex := func(s string, width int) int {
 			l, r := 0, len(s)+1
 			for l+1 < r {
 				mid := (l + r) >> 1
-				// if getMaxW(string([]rune(s)[:mid])) <= width {
 				if getMaxW(s[:mid]) <= width {
 					l = mid
 				} else {
@@ -34,6 +34,22 @@ func linesFitWidth(ss []string) []string {
 			}
 			return l
 		}
+
+		// count runes maybe invalid bytes at the end
+		countValidRunes := func(s string) int {
+			if s == "" {
+				return 0
+			}
+			// Remove all invalid bytes at the end
+			for {
+				r, size := utf8.DecodeLastRuneInString(s)
+				if r != utf8.RuneError || size != 1 {
+					break
+				}
+				s = s[:len(s)-1]
+			}
+			return utf8.RuneCountInString(s)
+		}
 		buffer := make([]string, 0)
 		for _, s := range ss {
 			if getMaxW(s) <= w {
@@ -41,11 +57,10 @@ func linesFitWidth(ss []string) []string {
 				continue
 			}
 			for len(s) > 0 {
-				i := findIndex(s, w)
-				// buffer = append(buffer, string([]rune(s)[:i]))
-				// s = string([]rune(s)[i:])
-				buffer = append(buffer, s[:i])
-				s = s[i:]
+				i := countValidRunes(s[:findIndex(s, w)])
+				front, end := string([]rune(s)[:i]), string([]rune(s)[i:])
+				buffer = append(buffer, front)
+				s = end
 			}
 		}
 		return buffer

--- a/interactive_multiselect_printer.go
+++ b/interactive_multiselect_printer.go
@@ -433,7 +433,7 @@ func (p *InteractiveMultiselectPrinter) renderSelectMenu() string {
 		content.WriteString(ThemeDefault.SecondaryStyle.Sprint("Selected: ") + Green(strings.Join(selected, Gray(", "))) + "\n")
 	}
 
-	return content.String()
+	return textFitWidth(content.String())
 }
 
 func (p InteractiveMultiselectPrinter) renderFinishedMenu() string {

--- a/interactive_select_printer.go
+++ b/interactive_select_printer.go
@@ -320,7 +320,7 @@ func (p *InteractiveSelectPrinter) renderSelectMenu() string {
 		}
 	}
 
-	return content.String()
+	return textFitWidth(content.String())
 }
 
 func (p InteractiveSelectPrinter) renderFinishedMenu() string {

--- a/interactive_textinput_printer.go
+++ b/interactive_textinput_printer.go
@@ -2,8 +2,6 @@ package pterm
 
 import (
 	"strings"
-	"sync"
-	"time"
 
 	"atomicgo.dev/cursor"
 	"atomicgo.dev/keyboard"
@@ -166,24 +164,14 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 	updateActualYX()
 
 	area := cursor.NewArea()
-	p.updateArea(&area, p.fitInput)
+	p.updateArea(&area, inputfirstLineOffset())
 
-	// watch and fit the terminal width
-	var mu sync.Mutex
-	fitDone := make(chan struct{})
-	defer close(fitDone)
-	go func() {
-		watchWidth(fitDone, 100*time.Millisecond, func(w int) {
-			mu.Lock()
-			defer mu.Unlock()
-			updateActualYX()
-			p.updateArea(&area, p.fitInput)
-		})
-	}()
-
+	width := GetTerminalWidth()
 	err := keyboard.Listen(func(key keys.Key) (stop bool, err error) {
-		mu.Lock()
-		defer mu.Unlock()
+
+		if w := GetTerminalWidth(); w != width {
+			updateActualYX()
+		}
 
 		if len(p.input) == 0 {
 			p.input = append(p.input, "")
@@ -340,18 +328,7 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 		// update logic coord
 		updateLogicYX()
 
-		// handle the mask
-		areaInput := make([]string, 0)
-		if p.Mask != "" {
-			for _, s := range p.input {
-				areaInput = append(areaInput, strings.Repeat(p.Mask, getMaxW(s)))
-			}
-		} else {
-			areaInput = p.input
-		}
-		// render to area
-		areaInput = inputFitWidth(areaInput)
-		p.updateArea(&area, areaInput)
+		p.updateArea(&area, inputfirstLineOffset())
 
 		return false, nil
 	})
@@ -369,11 +346,17 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 	return strings.Join(p.input, "\n"), nil
 }
 
-func (p InteractiveTextInputPrinter) updateArea(area *cursor.Area, fitInput []string) string {
+func (p InteractiveTextInputPrinter) updateArea(area *cursor.Area, offest int) string {
 
 	areaText := textFitWidth(p.text)
 	areaContent := areaText
-	areaContent += strings.Join(fitInput, "\n")
+	areaInput := linesFitWidth(p.input, offest)
+	if p.Mask != "" {
+		for i := 0; i < len(areaInput); i++ {
+			areaInput[i] = strings.Repeat(p.Mask, getMaxW(areaInput[i]))
+		}
+	}
+	areaContent += strings.Join(areaInput, "\n")
 
 	area.Update(areaContent)
 
@@ -384,10 +367,9 @@ func (p InteractiveTextInputPrinter) updateArea(area *cursor.Area, fitInput []st
 	// cursor right offset
 	area.StartOfLine()
 	if p.MultiLine || y != 0 {
-		cursor.Right(getMaxW(fitInput[y]) + x)
+		cursor.Right(getMaxW(areaInput[y]) + x)
 	} else {
-		lines := strings.Split(p.text, "\n")
-		cursor.Right(getMaxW(lines[len(lines)-1]) + getMaxW(fitInput[y]) + x)
+		cursor.Right(offest + getMaxW(areaInput[y]) + x)
 	}
 
 	return areaContent

--- a/interactive_textinput_printer.go
+++ b/interactive_textinput_printer.go
@@ -6,7 +6,6 @@ import (
 	"atomicgo.dev/cursor"
 	"atomicgo.dev/keyboard"
 	"atomicgo.dev/keyboard/keys"
-	"github.com/mattn/go-runewidth"
 
 	"github.com/pterm/pterm/internal"
 )
@@ -102,19 +101,11 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 	area.Update(areaText)
 	area.StartOfLine()
 
-	if !p.MultiLine {
-		cursor.Right(runewidth.StringWidth(RemoveColorFromString(areaText)))
-	}
-
-	if p.DefaultValue != "" {
-		p.input = append(p.input, p.DefaultValue)
-		p.updateArea(&area)
-	}
+	p.input = append(p.input, strings.Split(p.DefaultValue, "\n")...)
+	p.cursorYPos = len(p.input) - 1
+	p.updateArea(&area)
 
 	err := keyboard.Listen(func(key keys.Key) (stop bool, err error) {
-		if !p.MultiLine {
-			p.cursorYPos = 0
-		}
 
 		if len(p.input) == 0 {
 			p.input = append(p.input, "")
@@ -151,7 +142,7 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 				p.input = append(p.input[:p.cursorYPos+1], appendAfterX)
 				p.input = append(p.input, appendAfterY...)
 				p.cursorYPos++
-				p.cursorXPos = -internal.GetStringMaxWidth(p.input[p.cursorYPos])
+				p.cursorXPos = -getMaxW(p.input[p.cursorYPos])
 
 				cursor.StartOfLine()
 			} else {
@@ -214,12 +205,11 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 			}
 
 			if !p.startedTyping {
-				p.input = []string{""}
 				p.startedTyping = true
 			}
 
 			if p.cursorYPos+1 < len(p.input) {
-				p.cursorXPos = min((internal.GetStringMaxWidth(p.input[p.cursorYPos])+p.cursorXPos)-internal.GetStringMaxWidth(p.input[p.cursorYPos+1]), 0)
+				p.cursorXPos = min((getMaxW(p.input[p.cursorYPos])+p.cursorXPos)-getMaxW(p.input[p.cursorYPos+1]), 0)
 
 				p.cursorYPos++
 			}
@@ -230,29 +220,28 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 			}
 
 			if !p.startedTyping {
-				p.input = []string{""}
 				p.startedTyping = true
 			}
 
 			if p.cursorYPos > 0 {
-				p.cursorXPos = min((internal.GetStringMaxWidth(p.input[p.cursorYPos])+p.cursorXPos)-internal.GetStringMaxWidth(p.input[p.cursorYPos-1]), 0)
+				p.cursorXPos = min((getMaxW(p.input[p.cursorYPos])+p.cursorXPos)-getMaxW(p.input[p.cursorYPos-1]), 0)
 
 				p.cursorYPos--
 			}
 		}
 
-		if internal.GetStringMaxWidth(p.input[p.cursorYPos]) > 0 {
+		if getMaxW(p.input[p.cursorYPos]) > 0 {
 			switch key.Code {
 			case keys.Right:
 				if p.cursorXPos < 0 {
 					p.cursorXPos++
 				} else if p.cursorYPos < len(p.input)-1 {
 					p.cursorYPos++
-					p.cursorXPos = -internal.GetStringMaxWidth(p.input[p.cursorYPos])
+					p.cursorXPos = -getMaxW(p.input[p.cursorYPos])
 				}
 
 			case keys.Left:
-				if p.cursorXPos+internal.GetStringMaxWidth(p.input[p.cursorYPos]) > 0 {
+				if p.cursorXPos+getMaxW(p.input[p.cursorYPos]) > 0 {
 					p.cursorXPos--
 				} else if p.cursorYPos > 0 {
 					p.cursorYPos--
@@ -288,38 +277,34 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 }
 
 func (p InteractiveTextInputPrinter) updateArea(area *cursor.Area) string {
-	if !p.MultiLine {
-		p.cursorYPos = 0
-	}
 
-	areaText := p.text
+	areaContent := p.text
 
-	for i, s := range p.input {
-		if i < len(p.input)-1 {
-			areaText += s + "\n"
-		} else {
-			areaText += s
-		}
-	}
+	areaContent += strings.Join(p.input, "\n")
 
 	if p.Mask != "" {
-		areaText = p.text + strings.Repeat(p.Mask, internal.GetStringMaxWidth(areaText)-internal.GetStringMaxWidth(p.text))
+		areaContent = p.text + strings.Repeat(p.Mask, getMaxW(areaContent)-getMaxW(p.text))
 	}
 
-	if p.cursorXPos+internal.GetStringMaxWidth(p.input[p.cursorYPos]) < 1 {
-		p.cursorXPos = -internal.GetStringMaxWidth(p.input[p.cursorYPos])
+	if p.cursorXPos+getMaxW(p.input[p.cursorYPos]) < 1 {
+		p.cursorXPos = -getMaxW(p.input[p.cursorYPos])
 	}
 
-	area.Update(areaText)
+	area.Update(areaContent)
 	area.Top()
-	area.Down(p.cursorYPos + 1)
+	area.Down(strings.Count(p.text, "\n"))
+	area.Down(p.cursorYPos)
+	if p.MultiLine {
+		area.Down(1)
+	}
 	area.StartOfLine()
 
-	if p.MultiLine {
-		cursor.Right(internal.GetStringMaxWidth(p.input[p.cursorYPos]) + p.cursorXPos)
+	if p.MultiLine || p.cursorYPos != 0 {
+		cursor.Right(getMaxW(p.input[p.cursorYPos]) + p.cursorXPos)
 	} else {
-		cursor.Right(internal.GetStringMaxWidth(areaText) + p.cursorXPos)
+		lines := strings.Split(p.text, "\n")
+		cursor.Right(getMaxW(lines[len(lines)-1]) + getMaxW(p.input[p.cursorYPos]) + p.cursorXPos)
 	}
 
-	return areaText
+	return areaContent
 }

--- a/interactive_textinput_printer.go
+++ b/interactive_textinput_printer.go
@@ -102,8 +102,8 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 			}
 			px := -getMaxW(logicLine)
 			for _, line := range linesFitWidth([]string{logicLine}) {
-				px += getMaxW(line) - 1
-				cMap = append(cMap, coord{y: py, end: px + 1})
+				px += getMaxW(line)
+				cMap = append(cMap, coord{y: py, end: px})
 			}
 		}
 	}
@@ -116,6 +116,7 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 		for ay, c := range cMap {
 			if py == c.y && px <= c.end {
 				y, x = ay, px-c.end
+				break
 			}
 		}
 		return y, x
@@ -206,6 +207,8 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 			p.input = append(p.input, "")
 		}
 
+		updateLogicYX()
+
 		switch key.Code {
 		case keys.Tab:
 			if p.MultiLine {
@@ -241,20 +244,20 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 			}
 
 		case keys.RuneKey:
-			// TODO RuneKey case
 			if !p.startedTyping {
 				p.startedTyping = true
 			}
 
 			p.input[p.cursorYPos] = string(append([]rune(p.input[p.cursorYPos])[:len([]rune(p.input[p.cursorYPos]))+p.cursorXPos], append([]rune(key.String()), []rune(p.input[p.cursorYPos])[len([]rune(p.input[p.cursorYPos]))+p.cursorXPos:]...)...))
+			updateActualYX()
 
 		case keys.Space:
-			// TODO Space case
 			if !p.startedTyping {
 				p.startedTyping = true
 			}
 
 			p.input[p.cursorYPos] = string(append([]rune(p.input[p.cursorYPos])[:len([]rune(p.input[p.cursorYPos]))+p.cursorXPos], append([]rune(" "), []rune(p.input[p.cursorYPos])[len([]rune(p.input[p.cursorYPos]))+p.cursorXPos:]...)...))
+			updateActualYX()
 
 		case keys.Backspace:
 			// TODO Backspace case

--- a/interactive_textinput_printer.go
+++ b/interactive_textinput_printer.go
@@ -94,14 +94,17 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 	// c:=cMap[ay],py=c.y,px=ax+c.end
 	var cMap []coord
 
+	// Returns the width of the last line of p.text
 	inputfirstLineOffset := func() int {
 		lines := strings.Split(textFitWidth(p.text), "\n")
 		return getMaxW(lines[len(lines)-1])
 	}
+	// update cMap
 	updateCoords := func() {
 		cMap = make([]coord, 0, len(p.fitInput))
 		for py, logicLine := range p.input {
 			offset := 0
+			// When the first row, offset.
 			if py == 0 {
 				offset = inputfirstLineOffset()
 			}
@@ -112,10 +115,12 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 			}
 		}
 	}
+	// Map coordinates on the actual terminal to logical coordinates of p. input
 	logicYX := func(ay, ax int) (int, int) {
 		c := cMap[ay]
 		return c.y, ax + c.end
 	}
+	// Mapping logical coordinates to actual coordinates in the terminal
 	actualYX := func(py, px int) (int, int) {
 		var y, x int
 		for ay, c := range cMap {
@@ -154,44 +159,12 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 
 	p.text = areaText
 
+	// Initialize logic input values, update actual coordinates
 	p.input = append(p.input, strings.Split(p.DefaultValue, "\n")...)
 	p.cursorYPos = len(p.input) - 1
 	p.cursorXPos = 0
 	updateActualYX()
 
-	// !remove brefore PR
-	textLog := func() {
-		l := func(a ...any) { p.text += Sprintln(a...) }
-		pink := NewRGB(255, 0, 200).Sprintf
-		y := NewRGB(251, 255, 0).Sprint
-		b := NewRGB(88, 91, 255).Sprint
-		g := NewRGB(21, 255, 0).Sprint
-		o := NewRGB(255, 94, 0).Sprint
-
-		p.text = LightRed("--------------\n")
-		l(Sprint(pink("█"), y("█"), b("█"), g("█"), o("█")))
-		l(Sprint(pink("width:"), o(GetTerminalWidth())))
-		l(Sprintf("%v Y:%v X:%v L:%v",
-			pink("lgc"), g(p.cursorYPos), g(p.cursorXPos),
-			y(getMaxW(p.input[p.cursorYPos]))))
-		l(Sprintf("%v Y:%v X:%v L:%v",
-			pink("act"), g(p.actualY), g(p.actualX),
-			y(getMaxW(p.fitInput[p.actualY]))))
-
-		l(b(Sprintf("%q", p.input)))
-		l(b(Sprintf("%q", p.fitInput)))
-		for k, v := range cMap {
-			l(b(Sprintf("%v:(y:%v,end:%v)", k, v.y, v.end)))
-		}
-
-		p.text += LightRed("--------------")
-		if p.MultiLine {
-			p.text += "\n"
-		}
-	}
-	// textLog()
-	updateActualYX()
-	// textLog()
 	area := cursor.NewArea()
 	p.updateArea(&area, p.fitInput)
 
@@ -215,8 +188,6 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 		if len(p.input) == 0 {
 			p.input = append(p.input, "")
 		}
-
-		updateLogicYX()
 
 		switch key.Code {
 		case keys.Tab:
@@ -364,18 +335,13 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 				p.actualY--
 				p.actualX = 0
 			}
-
-		case keys.Esc:
-			textLog()
 		}
 
 		// update logic coord
 		updateLogicYX()
 
-		// textLog()
-		// update the input buffer
-		areaInput := make([]string, 0)
 		// handle the mask
+		areaInput := make([]string, 0)
 		if p.Mask != "" {
 			for _, s := range p.input {
 				areaInput = append(areaInput, strings.Repeat(p.Mask, getMaxW(s)))
@@ -383,7 +349,7 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 		} else {
 			areaInput = p.input
 		}
-
+		// render to area
 		areaInput = inputFitWidth(areaInput)
 		p.updateArea(&area, areaInput)
 

--- a/interactive_textinput_printer.go
+++ b/interactive_textinput_printer.go
@@ -96,10 +96,6 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 	updateCoords := func() {
 		cMap = make([]coord, 0, len(p.fitInput))
 		for py, logicLine := range p.input {
-			if getMaxW(logicLine) < GetTerminalWidth() {
-				cMap = append(cMap, coord{y: py, end: 0})
-				continue
-			}
 			px := -getMaxW(logicLine)
 			for _, line := range linesFitWidth([]string{logicLine}) {
 				px += getMaxW(line)
@@ -146,33 +142,6 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 	}
 
 	p.text = areaText
-	// !remove brefore PR
-	textLog := func() {
-		l := func(a ...any) { p.text += Sprintln(a...) }
-		pink := NewRGB(255, 0, 200).Sprintf
-		y := NewRGB(251, 255, 0).Sprint
-		b := NewRGB(88, 91, 255).Sprint
-		g := NewRGB(21, 255, 0).Sprint
-		o := NewRGB(255, 94, 0).Sprint
-
-		p.text = LightRed("--------------\n")
-		l(Sprint(pink("█"), y("█"), b("█"), g("█"), o("█")))
-		l(Sprint(pink("width:"), o(GetTerminalWidth())))
-		l(Sprintf("%v Y:%v X:%v L:%v",
-			pink("lgc"), g(p.cursorYPos), g(p.cursorXPos),
-			y(getMaxW(p.input[p.cursorYPos]))))
-		l(Sprintf("%v Y:%v X:%v L:%v",
-			pink("act"), g(p.actualY), g(p.actualX),
-			y(getMaxW(p.fitInput[p.actualY]))))
-
-		l(b(Sprintf("%q", p.input)))
-		l(b(Sprintf("%q", p.fitInput)))
-		for k, v := range cMap {
-			l(b(Sprintf("%v:(y:%v,end:%v)", k, v.y, v.end)))
-		}
-
-		p.text += LightRed("--------------\n")
-	}
 
 	p.input = append(p.input, strings.Split(p.DefaultValue, "\n")...)
 	p.cursorYPos = len(p.input) - 1
@@ -180,8 +149,6 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 	p.fitInput = linesFitWidth(p.input)
 	updateActualYX()
 
-	// !remove brefore PR
-	textLog()
 	area := cursor.NewArea()
 
 	p.updateArea(&area, p.fitInput)
@@ -278,7 +245,12 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 
 		case keys.Delete:
 			if !p.startedTyping {
+				p.input = []string{""}
 				p.startedTyping = true
+				p.cursorXPos = 0
+				p.cursorYPos = 0
+				updateActualYX()
+				return false, nil
 			}
 
 			handle := func() {
@@ -348,9 +320,6 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 
 		// update logic coord
 		updateLogicYX()
-
-		// !remove brefore PR
-		textLog()
 
 		// update the input buffer
 		areaInput := make([]string, 0)

--- a/interactive_textinput_printer.go
+++ b/interactive_textinput_printer.go
@@ -29,6 +29,7 @@ type InteractiveTextInputPrinter struct {
 	OnInterruptFunc func()
 
 	input         []string
+	fitInput      []string
 	cursorXPos    int
 	cursorYPos    int
 	text          string
@@ -103,7 +104,7 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 
 	p.input = append(p.input, strings.Split(p.DefaultValue, "\n")...)
 	p.cursorYPos = len(p.input) - 1
-	p.updateArea(&area)
+	p.updateArea(&area, p.input, p.cursorXPos, p.cursorYPos)
 
 	err := keyboard.Listen(func(key keys.Key) (stop bool, err error) {
 
@@ -119,16 +120,8 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 			}
 
 		case keys.Enter:
-			if p.DefaultValue != "" && !p.startedTyping {
-				for i := range p.input {
-					p.input[i] = RemoveColorFromString(p.input[i])
-				}
-
-				if p.MultiLine {
-					area.Bottom()
-				}
-
-				return true, nil
+			if !p.startedTyping {
+				p.startedTyping = true
 			}
 
 			if p.MultiLine {
@@ -250,7 +243,34 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 			}
 		}
 
-		p.updateArea(&area)
+		// for test
+		{
+			l := func(a ...any) { p.text += Sprintln(a...) }
+			pink := NewRGB(255, 0, 200).Sprint
+			y := NewRGB(251, 255, 0).Sprint
+			b := NewRGB(88, 91, 255).Sprint
+			g := NewRGB(21, 255, 0).Sprint
+
+			p.text = LightRed("--------------\n")
+			l(Sprint(pink("███"), y("███"), b("███"), g("███")))
+			l(Sprintf("%v Y:%v X:%v", pink("logic"), y(p.cursorYPos), g(p.cursorXPos)))
+			l(pink("input:"), b(Sprintf("%q", p.input)))
+			p.text += LightRed("--------------\n")
+		}
+
+		// update the input buffer
+		inputBuffer := make([]string, len(p.input))
+		// handle the mask
+		if p.Mask != "" {
+			for _, s := range p.input {
+				inputBuffer = append(inputBuffer, strings.Repeat(p.Mask, getMaxW(s)))
+			}
+		} else {
+			inputBuffer = p.input
+		}
+
+		// TODO update area with actual coord
+		p.updateArea(&area, inputBuffer, p.cursorXPos, p.cursorYPos)
 
 		return false, nil
 	})
@@ -261,49 +281,41 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 	// Add new line
 	Println()
 
-	for i, s := range p.input {
-		if i < len(p.input)-1 {
-			areaText += s + "\n"
-		} else {
-			areaText += s
-		}
-	}
-
 	if !p.startedTyping {
 		return p.DefaultValue, nil
 	}
 
-	return strings.ReplaceAll(areaText, p.text, ""), nil
+	return strings.Join(p.input, "\n"), nil
 }
 
-func (p InteractiveTextInputPrinter) updateArea(area *cursor.Area) string {
+func (p InteractiveTextInputPrinter) updateArea(area *cursor.Area, input []string, x, y int) string {
 
-	areaContent := p.text
+	textLines := linesFitWidth(strings.Split(p.text, "\n"))
+	areaContent := strings.Join(textLines, "\n")
 
-	areaContent += strings.Join(p.input, "\n")
+	// TODO fit input
+	x, y = p.cursorXPos, p.cursorYPos
+	areaInput := input
 
-	if p.Mask != "" {
-		areaContent = p.text + strings.Repeat(p.Mask, getMaxW(areaContent)-getMaxW(p.text))
-	}
+	areaContent += strings.Join(areaInput, "\n")
 
-	if p.cursorXPos+getMaxW(p.input[p.cursorYPos]) < 1 {
-		p.cursorXPos = -getMaxW(p.input[p.cursorYPos])
-	}
+	// // reserved code
+	// if x+getMaxW(areaInput[y]) < 1 {
+	// 	x = -getMaxW(areaInput[y])
+	// }
 
 	area.Update(areaContent)
+	// cursor down offset
 	area.Top()
-	area.Down(strings.Count(p.text, "\n"))
-	area.Down(p.cursorYPos)
-	if p.MultiLine {
-		area.Down(1)
-	}
+	area.Down(len(textLines))
+	area.Down(y)
+	// cursor right offset
 	area.StartOfLine()
-
-	if p.MultiLine || p.cursorYPos != 0 {
-		cursor.Right(getMaxW(p.input[p.cursorYPos]) + p.cursorXPos)
+	if p.MultiLine || y != 0 {
+		cursor.Right(getMaxW(areaInput[y]) + x)
 	} else {
 		lines := strings.Split(p.text, "\n")
-		cursor.Right(getMaxW(lines[len(lines)-1]) + getMaxW(p.input[p.cursorYPos]) + p.cursorXPos)
+		cursor.Right(getMaxW(lines[len(lines)-1]) + getMaxW(areaInput[y]) + x)
 	}
 
 	return areaContent

--- a/interactive_textinput_printer.go
+++ b/interactive_textinput_printer.go
@@ -171,6 +171,7 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 
 		if w := GetTerminalWidth(); w != width {
 			updateActualYX()
+			width = w
 		}
 
 		if len(p.input) == 0 {
@@ -350,7 +351,7 @@ func (p InteractiveTextInputPrinter) updateArea(area *cursor.Area, offest int) s
 
 	areaText := textFitWidth(p.text)
 	areaContent := areaText
-	areaInput := linesFitWidth(p.input, offest)
+	areaInput := append([]string{}, linesFitWidth(p.input, offest)...)
 	if p.Mask != "" {
 		for i := 0; i < len(areaInput); i++ {
 			areaInput[i] = strings.Repeat(p.Mask, getMaxW(areaInput[i]))

--- a/interactive_textinput_printer.go
+++ b/interactive_textinput_printer.go
@@ -290,14 +290,12 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 
 func (p InteractiveTextInputPrinter) updateArea(area *cursor.Area, input []string, x, y int) string {
 
-	textLines := linesFitWidth(strings.Split(p.text, "\n"))
-	areaContent := strings.Join(textLines, "\n")
+	areaText := textFitWidth(p.text)
+	areaContent := areaText
 
 	// TODO fit input
 	x, y = p.cursorXPos, p.cursorYPos
 	areaInput := input
-
-	areaContent += strings.Join(areaInput, "\n")
 
 	// // reserved code
 	// if x+getMaxW(areaInput[y]) < 1 {
@@ -307,8 +305,7 @@ func (p InteractiveTextInputPrinter) updateArea(area *cursor.Area, input []strin
 	area.Update(areaContent)
 	// cursor down offset
 	area.Top()
-	area.Down(len(textLines))
-	area.Down(y)
+	area.Down(strings.Count(areaText, "\n") + y)
 	// cursor right offset
 	area.StartOfLine()
 	if p.MultiLine || y != 0 {

--- a/interactive_textinput_printer.go
+++ b/interactive_textinput_printer.go
@@ -2,6 +2,8 @@ package pterm
 
 import (
 	"strings"
+	"sync"
+	"time"
 
 	"atomicgo.dev/cursor"
 	"atomicgo.dev/keyboard"
@@ -30,6 +32,8 @@ type InteractiveTextInputPrinter struct {
 
 	input         []string
 	fitInput      []string
+	actualX       int
+	actualY       int
 	cursorXPos    int
 	cursorYPos    int
 	text          string
@@ -85,6 +89,49 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 	cancel, exit := internal.NewCancelationSignal(p.OnInterruptFunc)
 	defer exit()
 
+	type coord struct{ y, end int }
+	// coordinate mapping
+	// c:=cMap[ay],py=c.y,px=ax+c.end
+	var cMap []coord
+	updateCoords := func() {
+		cMap = make([]coord, 0, len(p.fitInput))
+		for py, logicLine := range p.input {
+			if getMaxW(logicLine) < GetTerminalWidth() {
+				cMap = append(cMap, coord{y: py, end: 0})
+				continue
+			}
+			px := -getMaxW(logicLine)
+			for _, line := range linesFitWidth([]string{logicLine}) {
+				px += getMaxW(line) - 1
+				cMap = append(cMap, coord{y: py, end: px + 1})
+			}
+		}
+	}
+	logicYX := func(ay, ax int) (int, int) {
+		c := cMap[ay]
+		return c.y, ax + c.end
+	}
+	actualYX := func(py, px int) (int, int) {
+		var y, x int
+		for ay, c := range cMap {
+			if py == c.y && px <= c.end {
+				y, x = ay, px-c.end
+			}
+		}
+		return y, x
+	}
+	updateFitInput := func() { p.fitInput = linesFitWidth(p.input) }
+	updateLogicYX := func() {
+		updateFitInput()
+		updateCoords()
+		p.cursorYPos, p.cursorXPos = logicYX(p.actualY, p.actualX)
+	}
+	updateActualYX := func() {
+		updateFitInput()
+		updateCoords()
+		p.actualY, p.actualX = actualYX(p.cursorYPos, p.cursorXPos)
+	}
+
 	var areaText string
 
 	if len(text) == 0 || text[0] == "" {
@@ -98,15 +145,62 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 	}
 
 	p.text = areaText
-	area := cursor.NewArea()
-	area.Update(areaText)
-	area.StartOfLine()
+	// !remove brefore PR
+	textLog := func() {
+		l := func(a ...any) { p.text += Sprintln(a...) }
+		pink := NewRGB(255, 0, 200).Sprintf
+		y := NewRGB(251, 255, 0).Sprint
+		b := NewRGB(88, 91, 255).Sprint
+		g := NewRGB(21, 255, 0).Sprint
+		o := NewRGB(255, 94, 0).Sprint
+
+		p.text = LightRed("--------------\n")
+		l(Sprint(pink("█"), y("█"), b("█"), g("█"), o("█")))
+		l(Sprint(pink("width:"), o(GetTerminalWidth())))
+		l(Sprintf("%v Y:%v X:%v L:%v",
+			pink("lgc"), g(p.cursorYPos), g(p.cursorXPos),
+			y(getMaxW(p.input[p.cursorYPos]))))
+		l(Sprintf("%v Y:%v X:%v L:%v",
+			pink("act"), g(p.actualY), g(p.actualX),
+			y(getMaxW(p.fitInput[p.actualY]))))
+
+		l(b(Sprintf("%q", p.input)))
+		l(b(Sprintf("%q", p.fitInput)))
+		for k, v := range cMap {
+			l(b(Sprintf("%v:(y:%v,end:%v)", k, v.y, v.end)))
+		}
+
+		p.text += LightRed("--------------\n")
+	}
 
 	p.input = append(p.input, strings.Split(p.DefaultValue, "\n")...)
 	p.cursorYPos = len(p.input) - 1
-	p.updateArea(&area, p.input, p.cursorXPos, p.cursorYPos)
+	p.cursorXPos = 0
+	p.fitInput = linesFitWidth(p.input)
+	updateActualYX()
+
+	// !remove brefore PR
+	textLog()
+	area := cursor.NewArea()
+
+	p.updateArea(&area, p.fitInput)
+
+	// watch and fit the terminal width
+	var mu sync.Mutex
+	fitDone := make(chan struct{})
+	defer close(fitDone)
+	go func() {
+		watchWidth(fitDone, 100*time.Millisecond, func(w int) {
+			mu.Lock()
+			defer mu.Unlock()
+			updateActualYX()
+			p.updateArea(&area, p.fitInput)
+		})
+	}()
 
 	err := keyboard.Listen(func(key keys.Key) (stop bool, err error) {
+		mu.Lock()
+		defer mu.Unlock()
 
 		if len(p.input) == 0 {
 			p.input = append(p.input, "")
@@ -120,14 +214,17 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 			}
 
 		case keys.Enter:
+			// TODO review Enter case
 			if !p.startedTyping {
 				p.startedTyping = true
 			}
 
 			if p.MultiLine {
 				if key.AltPressed {
-					p.cursorXPos = 0
+					p.actualX = 0
 				}
+
+				updateLogicYX()
 
 				appendAfterY := append([]string{}, p.input[p.cursorYPos+1:]...)
 				appendAfterX := string(append([]rune{}, []rune(p.input[p.cursorYPos])[len([]rune(p.input[p.cursorYPos]))+p.cursorXPos:]...))
@@ -137,12 +234,14 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 				p.cursorYPos++
 				p.cursorXPos = -getMaxW(p.input[p.cursorYPos])
 
-				cursor.StartOfLine()
+				updateActualYX()
+
 			} else {
 				return true, nil
 			}
 
 		case keys.RuneKey:
+			// TODO RuneKey case
 			if !p.startedTyping {
 				p.startedTyping = true
 			}
@@ -150,6 +249,7 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 			p.input[p.cursorYPos] = string(append([]rune(p.input[p.cursorYPos])[:len([]rune(p.input[p.cursorYPos]))+p.cursorXPos], append([]rune(key.String()), []rune(p.input[p.cursorYPos])[len([]rune(p.input[p.cursorYPos]))+p.cursorXPos:]...)...))
 
 		case keys.Space:
+			// TODO Space case
 			if !p.startedTyping {
 				p.startedTyping = true
 			}
@@ -157,120 +257,113 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 			p.input[p.cursorYPos] = string(append([]rune(p.input[p.cursorYPos])[:len([]rune(p.input[p.cursorYPos]))+p.cursorXPos], append([]rune(" "), []rune(p.input[p.cursorYPos])[len([]rune(p.input[p.cursorYPos]))+p.cursorXPos:]...)...))
 
 		case keys.Backspace:
+			// TODO Backspace case
 			if !p.startedTyping {
 				p.startedTyping = true
 			}
 
-			if len([]rune(p.input[p.cursorYPos]))+p.cursorXPos > 0 {
-				p.input[p.cursorYPos] = string(append([]rune(p.input[p.cursorYPos])[:len([]rune(p.input[p.cursorYPos]))-1+p.cursorXPos], []rune(p.input[p.cursorYPos])[len([]rune(p.input[p.cursorYPos]))+p.cursorXPos:]...))
-			} else if p.cursorYPos > 0 {
-				p.input[p.cursorYPos-1] += p.input[p.cursorYPos]
-				appendAfterY := append([]string{}, p.input[p.cursorYPos+1:]...)
-				p.input = append(p.input[:p.cursorYPos], appendAfterY...)
-				p.cursorXPos = 0
-				p.cursorYPos--
+			handle := func() {
+				if len([]rune(p.input[p.cursorYPos]))+p.cursorXPos > 0 {
+					p.input[p.cursorYPos] = string(append([]rune(p.input[p.cursorYPos])[:len([]rune(p.input[p.cursorYPos]))-1+p.cursorXPos], []rune(p.input[p.cursorYPos])[len([]rune(p.input[p.cursorYPos]))+p.cursorXPos:]...))
+				} else if p.cursorYPos > 0 {
+					p.input[p.cursorYPos-1] += p.input[p.cursorYPos]
+					appendAfterY := append([]string{}, p.input[p.cursorYPos+1:]...)
+					p.input = append(p.input[:p.cursorYPos], appendAfterY...)
+					p.cursorXPos = 0
+					p.cursorYPos--
+				}
 			}
+			handle()
 
 		case keys.Delete:
+			// TODO Delete case
 			if !p.startedTyping {
-				p.input = []string{""}
 				p.startedTyping = true
-
-				return false, nil
 			}
 
-			if len([]rune(p.input[p.cursorYPos]))+p.cursorXPos < len([]rune(p.input[p.cursorYPos])) {
-				p.input[p.cursorYPos] = string(append([]rune(p.input[p.cursorYPos])[:len([]rune(p.input[p.cursorYPos]))+p.cursorXPos], []rune(p.input[p.cursorYPos])[len([]rune(p.input[p.cursorYPos]))+p.cursorXPos+1:]...))
-				p.cursorXPos++
-			} else if p.cursorYPos < len(p.input)-1 {
-				p.input[p.cursorYPos] += p.input[p.cursorYPos+1]
-				appendAfterY := append([]string{}, p.input[p.cursorYPos+2:]...)
-				p.input = append(p.input[:p.cursorYPos+1], appendAfterY...)
-				p.cursorXPos = 0
+			handle := func() {
+				if len([]rune(p.input[p.cursorYPos]))+p.cursorXPos < len([]rune(p.input[p.cursorYPos])) {
+					p.input[p.cursorYPos] = string(append([]rune(p.input[p.cursorYPos])[:len([]rune(p.input[p.cursorYPos]))+p.cursorXPos], []rune(p.input[p.cursorYPos])[len([]rune(p.input[p.cursorYPos]))+p.cursorXPos+1:]...))
+					p.cursorXPos++
+				} else if p.cursorYPos < len(p.input)-1 {
+					p.input[p.cursorYPos] += p.input[p.cursorYPos+1]
+					appendAfterY := append([]string{}, p.input[p.cursorYPos+2:]...)
+					p.input = append(p.input[:p.cursorYPos+1], appendAfterY...)
+					p.cursorXPos = 0
+				}
 			}
+			handle()
 
 		case keys.CtrlC:
 			cancel()
 			return true, nil
-		case keys.Down:
-			if !p.MultiLine {
-				return false, nil
-			}
 
+		case keys.Down:
 			if !p.startedTyping {
 				p.startedTyping = true
 			}
 
-			if p.cursorYPos+1 < len(p.input) {
-				p.cursorXPos = min((getMaxW(p.input[p.cursorYPos])+p.cursorXPos)-getMaxW(p.input[p.cursorYPos+1]), 0)
+			if p.actualY+1 < len(p.fitInput) {
+				p.actualX = min((getMaxW(p.fitInput[p.actualY])+p.actualX)-getMaxW(p.fitInput[p.actualY+1]), 0)
 
-				p.cursorYPos++
+				p.actualY++
 			}
 
 		case keys.Up:
-			if !p.MultiLine {
-				return false, nil
-			}
-
 			if !p.startedTyping {
 				p.startedTyping = true
 			}
 
-			if p.cursorYPos > 0 {
-				p.cursorXPos = min((getMaxW(p.input[p.cursorYPos])+p.cursorXPos)-getMaxW(p.input[p.cursorYPos-1]), 0)
+			if p.actualY > 0 {
+				p.actualX = min((getMaxW(p.fitInput[p.actualY])+p.actualX)-getMaxW(p.fitInput[p.actualY-1]), 0)
 
-				p.cursorYPos--
+				p.actualY--
 			}
-		}
 
-		if getMaxW(p.input[p.cursorYPos]) > 0 {
-			switch key.Code {
-			case keys.Right:
-				if p.cursorXPos < 0 {
-					p.cursorXPos++
-				} else if p.cursorYPos < len(p.input)-1 {
-					p.cursorYPos++
-					p.cursorXPos = -getMaxW(p.input[p.cursorYPos])
-				}
-
-			case keys.Left:
-				if p.cursorXPos+getMaxW(p.input[p.cursorYPos]) > 0 {
-					p.cursorXPos--
-				} else if p.cursorYPos > 0 {
-					p.cursorYPos--
-					p.cursorXPos = 0
-				}
+		case keys.Right:
+			if !p.startedTyping {
+				p.startedTyping = true
 			}
+			if p.actualX < 0 {
+				p.actualX++
+			} else if p.actualY < len(p.fitInput)-1 {
+				p.actualY++
+				p.actualX = -getMaxW(p.fitInput[p.actualY])
+			}
+
+		case keys.Left:
+			if !p.startedTyping {
+				p.startedTyping = true
+			}
+			if p.actualX+getMaxW(p.fitInput[p.actualY]) > 0 {
+				p.actualX--
+			} else if p.actualY > 0 {
+				p.actualY--
+				p.actualX = 0
+			}
+
+		case keys.Esc:
 		}
 
-		// for test
-		{
-			l := func(a ...any) { p.text += Sprintln(a...) }
-			pink := NewRGB(255, 0, 200).Sprint
-			y := NewRGB(251, 255, 0).Sprint
-			b := NewRGB(88, 91, 255).Sprint
-			g := NewRGB(21, 255, 0).Sprint
+		// update logic coord
+		updateLogicYX()
 
-			p.text = LightRed("--------------\n")
-			l(Sprint(pink("███"), y("███"), b("███"), g("███")))
-			l(Sprintf("%v Y:%v X:%v", pink("logic"), y(p.cursorYPos), g(p.cursorXPos)))
-			l(pink("input:"), b(Sprintf("%q", p.input)))
-			p.text += LightRed("--------------\n")
-		}
+		// !remove brefore PR
+		textLog()
 
 		// update the input buffer
-		inputBuffer := make([]string, len(p.input))
+		areaInput := make([]string, 0)
 		// handle the mask
 		if p.Mask != "" {
 			for _, s := range p.input {
-				inputBuffer = append(inputBuffer, strings.Repeat(p.Mask, getMaxW(s)))
+				areaInput = append(areaInput, strings.Repeat(p.Mask, getMaxW(s)))
 			}
 		} else {
-			inputBuffer = p.input
+			areaInput = p.input
 		}
 
-		// TODO update area with actual coord
-		p.updateArea(&area, inputBuffer, p.cursorXPos, p.cursorYPos)
+		areaInput = linesFitWidth(areaInput)
+		p.updateArea(&area, areaInput)
 
 		return false, nil
 	})
@@ -288,31 +381,25 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 	return strings.Join(p.input, "\n"), nil
 }
 
-func (p InteractiveTextInputPrinter) updateArea(area *cursor.Area, input []string, x, y int) string {
+func (p InteractiveTextInputPrinter) updateArea(area *cursor.Area, fitInput []string) string {
 
 	areaText := textFitWidth(p.text)
 	areaContent := areaText
-
-	// TODO fit input
-	x, y = p.cursorXPos, p.cursorYPos
-	areaInput := input
-
-	// // reserved code
-	// if x+getMaxW(areaInput[y]) < 1 {
-	// 	x = -getMaxW(areaInput[y])
-	// }
+	areaContent += strings.Join(fitInput, "\n")
 
 	area.Update(areaContent)
+
+	x, y := p.actualX, p.actualY
 	// cursor down offset
 	area.Top()
 	area.Down(strings.Count(areaText, "\n") + y)
 	// cursor right offset
 	area.StartOfLine()
 	if p.MultiLine || y != 0 {
-		cursor.Right(getMaxW(areaInput[y]) + x)
+		cursor.Right(getMaxW(fitInput[y]) + x)
 	} else {
 		lines := strings.Split(p.text, "\n")
-		cursor.Right(getMaxW(lines[len(lines)-1]) + getMaxW(areaInput[y]) + x)
+		cursor.Right(getMaxW(lines[len(lines)-1]) + getMaxW(fitInput[y]) + x)
 	}
 
 	return areaContent

--- a/interactive_textinput_printer.go
+++ b/interactive_textinput_printer.go
@@ -217,7 +217,6 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 			}
 
 		case keys.Enter:
-			// TODO review Enter case
 			if !p.startedTyping {
 				p.startedTyping = true
 			}
@@ -225,9 +224,8 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 			if p.MultiLine {
 				if key.AltPressed {
 					p.actualX = 0
+					updateLogicYX()
 				}
-
-				updateLogicYX()
 
 				appendAfterY := append([]string{}, p.input[p.cursorYPos+1:]...)
 				appendAfterX := string(append([]rune{}, []rune(p.input[p.cursorYPos])[len([]rune(p.input[p.cursorYPos]))+p.cursorXPos:]...))
@@ -260,7 +258,6 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 			updateActualYX()
 
 		case keys.Backspace:
-			// TODO Backspace case
 			if !p.startedTyping {
 				p.startedTyping = true
 			}
@@ -277,9 +274,9 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 				}
 			}
 			handle()
+			updateActualYX()
 
 		case keys.Delete:
-			// TODO Delete case
 			if !p.startedTyping {
 				p.startedTyping = true
 			}
@@ -289,13 +286,14 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 					p.input[p.cursorYPos] = string(append([]rune(p.input[p.cursorYPos])[:len([]rune(p.input[p.cursorYPos]))+p.cursorXPos], []rune(p.input[p.cursorYPos])[len([]rune(p.input[p.cursorYPos]))+p.cursorXPos+1:]...))
 					p.cursorXPos++
 				} else if p.cursorYPos < len(p.input)-1 {
+					p.cursorXPos = -getMaxW(p.input[p.cursorYPos+1])
 					p.input[p.cursorYPos] += p.input[p.cursorYPos+1]
 					appendAfterY := append([]string{}, p.input[p.cursorYPos+2:]...)
 					p.input = append(p.input[:p.cursorYPos+1], appendAfterY...)
-					p.cursorXPos = 0
 				}
 			}
 			handle()
+			updateActualYX()
 
 		case keys.CtrlC:
 			cancel()

--- a/interactive_textinput_printer.go
+++ b/interactive_textinput_printer.go
@@ -93,11 +93,20 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 	// coordinate mapping
 	// c:=cMap[ay],py=c.y,px=ax+c.end
 	var cMap []coord
+
+	inputfirstLineOffset := func() int {
+		lines := strings.Split(textFitWidth(p.text), "\n")
+		return getMaxW(lines[len(lines)-1])
+	}
 	updateCoords := func() {
 		cMap = make([]coord, 0, len(p.fitInput))
 		for py, logicLine := range p.input {
+			offset := 0
+			if py == 0 {
+				offset = inputfirstLineOffset()
+			}
 			px := -getMaxW(logicLine)
-			for _, line := range linesFitWidth([]string{logicLine}) {
+			for _, line := range linesFitWidth([]string{logicLine}, offset) {
 				px += getMaxW(line)
 				cMap = append(cMap, coord{y: py, end: px})
 			}
@@ -117,7 +126,9 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 		}
 		return y, x
 	}
-	updateFitInput := func() { p.fitInput = linesFitWidth(p.input) }
+
+	inputFitWidth := func(input []string) []string { return linesFitWidth(input, inputfirstLineOffset()) }
+	updateFitInput := func() { p.fitInput = inputFitWidth(p.input) }
 	updateLogicYX := func() {
 		updateFitInput()
 		updateCoords()
@@ -146,11 +157,42 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 	p.input = append(p.input, strings.Split(p.DefaultValue, "\n")...)
 	p.cursorYPos = len(p.input) - 1
 	p.cursorXPos = 0
-	p.fitInput = linesFitWidth(p.input)
 	updateActualYX()
 
-	area := cursor.NewArea()
+	// !remove brefore PR
+	textLog := func() {
+		l := func(a ...any) { p.text += Sprintln(a...) }
+		pink := NewRGB(255, 0, 200).Sprintf
+		y := NewRGB(251, 255, 0).Sprint
+		b := NewRGB(88, 91, 255).Sprint
+		g := NewRGB(21, 255, 0).Sprint
+		o := NewRGB(255, 94, 0).Sprint
 
+		p.text = LightRed("--------------\n")
+		l(Sprint(pink("█"), y("█"), b("█"), g("█"), o("█")))
+		l(Sprint(pink("width:"), o(GetTerminalWidth())))
+		l(Sprintf("%v Y:%v X:%v L:%v",
+			pink("lgc"), g(p.cursorYPos), g(p.cursorXPos),
+			y(getMaxW(p.input[p.cursorYPos]))))
+		l(Sprintf("%v Y:%v X:%v L:%v",
+			pink("act"), g(p.actualY), g(p.actualX),
+			y(getMaxW(p.fitInput[p.actualY]))))
+
+		l(b(Sprintf("%q", p.input)))
+		l(b(Sprintf("%q", p.fitInput)))
+		for k, v := range cMap {
+			l(b(Sprintf("%v:(y:%v,end:%v)", k, v.y, v.end)))
+		}
+
+		p.text += LightRed("--------------")
+		if p.MultiLine {
+			p.text += "\n"
+		}
+	}
+	// textLog()
+	updateActualYX()
+	// textLog()
+	area := cursor.NewArea()
 	p.updateArea(&area, p.fitInput)
 
 	// watch and fit the terminal width
@@ -184,8 +226,16 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 			}
 
 		case keys.Enter:
-			if !p.startedTyping {
-				p.startedTyping = true
+			if p.DefaultValue != "" && !p.startedTyping {
+				for i := range p.input {
+					p.input[i] = RemoveColorFromString(p.input[i])
+				}
+
+				if p.MultiLine {
+					area.Bottom()
+				}
+
+				return true, nil
 			}
 
 			if p.MultiLine {
@@ -316,11 +366,13 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 			}
 
 		case keys.Esc:
+			textLog()
 		}
 
 		// update logic coord
 		updateLogicYX()
 
+		// textLog()
 		// update the input buffer
 		areaInput := make([]string, 0)
 		// handle the mask
@@ -332,7 +384,7 @@ func (p InteractiveTextInputPrinter) Show(text ...string) (string, error) {
 			areaInput = p.input
 		}
 
-		areaInput = linesFitWidth(areaInput)
+		areaInput = inputFitWidth(areaInput)
 		p.updateArea(&area, areaInput)
 
 		return false, nil

--- a/interactive_textinput_printer_test.go
+++ b/interactive_textinput_printer_test.go
@@ -204,7 +204,7 @@ func TestInteractiveTextInputPrinter_InterruptCallsOnInterruptFunc(t *testing.T)
 	interrupted := false
 	printer := pterm.DefaultInteractiveTextInput.WithOnInterruptFunc(func() { interrupted = true })
 
-	simulateKeys(t, "abc", keys.CtrlC)
+	simulateKeys(t, 'a', 'b', 'c', keys.CtrlC)
 
 	result := showTextInput(t, printer)
 

--- a/internal/max_text_width.go
+++ b/internal/max_text_width.go
@@ -21,8 +21,3 @@ func GetStringMaxWidth(s string) int {
 
 	return maxString
 }
-
-// GetStringWidth returns the width of a string with removing OSC 8 hyperlinks and color codes
-func GetStringWidth(s string) int {
-	return runewidth.StringWidth(RemoveEscapeCodes(s))
-}

--- a/internal/max_text_width.go
+++ b/internal/max_text_width.go
@@ -21,3 +21,8 @@ func GetStringMaxWidth(s string) int {
 
 	return maxString
 }
+
+// GetStringWidth returns the width of a string with removing OSC 8 hyperlinks and color codes
+func GetStringWidth(s string) int {
+	return runewidth.StringWidth(RemoveEscapeCodes(s))
+}


### PR DESCRIPTION
Fixes #560
Also fixes #802

# Cause
`area.Update(content)` uses the number of `‘\n’` characters as `area.height`, which fails to adapt to the terminal width, causing the area to wrap to a new line and become misaligned. As `area` cannot clear the residual string caused by this misalignment, each call to `area.Update(content)` results in duplicate lines.

# Solution
1. Before calling `area.Update(content)`, wrap `content` according to the terminal width to prevent the terminal from inserting soft line breaks;
2. Resolve the cursor misalignment issue in `interactive_textinput_printer` caused by the fix by introducing coordinate mapping

# Testing
- All existing `interactive` series tests have passed

ps:
This resolves the issue of repeated printing caused by input exceeding the terminal’s width or the content string exceeding the terminal’s width; however, it does not address repeated printing caused by input exceeding the terminal’s height, nor the occasional repetition resulting from area misalignment due to soft line breaks triggered by changes to the terminal’s width.