### PR TITLE
feat(logger): preserve slog argument order and add SortArguments option

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -134,6 +135,10 @@ type Logger struct {
 	// The width is always capped to the current terminal width.
 	// A value of zero or less uses the full terminal width.
 	MaxWidth int
+	// SortArguments sorts the key-value arguments alphabetically by key before
+	// printing. When false (the default), arguments keep the order in which they
+	// were supplied.
+	SortArguments bool
 }
 
 // WithFormatter sets the log formatter of the logger.
@@ -187,6 +192,14 @@ func (l Logger) WithKeyStyles(styles map[string]Style) *Logger {
 // WithMaxWidth sets the maximum width of the logger.
 func (l Logger) WithMaxWidth(width int) *Logger {
 	l.MaxWidth = width
+	return &l
+}
+
+// WithSortArguments enables or disables alphabetical sorting of the key-value
+// arguments by key. When disabled (the default), arguments keep the order in
+// which they were supplied.
+func (l Logger) WithSortArguments(b ...bool) *Logger {
+	l.SortArguments = internal.WithBoolean(b)
 	return &l
 }
 
@@ -281,6 +294,12 @@ func (l Logger) combineArgs(args ...[]LoggerArgument) []LoggerArgument {
 
 	for _, arg := range args {
 		result = append(result, arg...)
+	}
+
+	if l.SortArguments {
+		slices.SortStableFunc(result, func(a, b LoggerArgument) int {
+			return strings.Compare(a.Key, b.Key)
+		})
 	}
 
 	return result

--- a/logger_test.go
+++ b/logger_test.go
@@ -139,6 +139,14 @@ func TestLoggerArgsFromMap(t *testing.T) {
 	assert.Equal(t, map[string]any{"a": 1, "b": "x"}, asMap)
 }
 
+func TestLoggerWithSortArguments(t *testing.T) {
+	p := pterm.Logger{}
+	p2 := p.WithSortArguments()
+
+	assert.True(t, p2.SortArguments)
+	assert.False(t, p.SortArguments)
+}
+
 // Colorful (text) formatter.
 
 func TestLoggerColorfulInlineFormat(t *testing.T) {
@@ -406,4 +414,25 @@ func TestSlogHandlerWithGroupFlattensAttrs(t *testing.T) {
 
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &m))
 	assert.Equal(t, "GET", m["method"])
+}
+
+func TestSlogHandlerPreservesArgumentOrder(t *testing.T) {
+	logger, buf := newBufferedLogger()
+	slogger := slog.New(pterm.NewSlogHandler(logger.WithLevel(pterm.LogLevelDebug)))
+
+	// WithAttrs attrs come first, then the record's own attrs, each in the order
+	// they were supplied. None of the keys are alphabetical, so a stable output
+	// proves the order is preserved rather than randomized by map iteration.
+	slogger.With("request_id", "abc123").Info("ordered", "zeta", 1, "alpha", 2, "mike", 3)
+
+	assert.Equal(t, "INFO  ordered request_id=abc123 zeta=1 alpha=2 mike=3\n", stripANSI(buf.String()))
+}
+
+func TestSlogHandlerSortArgumentsSortsAlphabetically(t *testing.T) {
+	logger, buf := newBufferedLogger()
+	slogger := slog.New(pterm.NewSlogHandler(logger.WithLevel(pterm.LogLevelDebug).WithSortArguments()))
+
+	slogger.Info("sorted", "zeta", 1, "alpha", 2, "mike", 3)
+
+	assert.Equal(t, "INFO  sorted alpha=2 mike=3 zeta=1\n", stripANSI(buf.String()))
 }

--- a/slog_handler.go
+++ b/slog_handler.go
@@ -33,19 +33,21 @@ func (s *SlogHandler) Handle(_ context.Context, record slog.Record) error {
 	level := record.Level
 	message := record.Message
 
-	// Convert slog Attrs to a map.
-	keyValsMap := make(map[string]any)
-
-	record.Attrs(func(attr slog.Attr) bool {
-		keyValsMap[attr.Key] = attr.Value
-		return true
-	})
+	// Collect the attrs in the order they were supplied, so the logger can print
+	// them predictably instead of in Go's randomized map order. Attrs bound via
+	// WithAttrs come first, followed by the record's own attrs, matching the
+	// behavior of slog's own text handler. Alphabetical ordering is available
+	// through the logger's SortArguments option.
+	args := make([]LoggerArgument, 0, len(s.attrs)+record.NumAttrs())
 
 	for _, attr := range s.attrs {
-		keyValsMap[attr.Key] = attr.Value
+		args = append(args, LoggerArgument{Key: attr.Key, Value: attr.Value})
 	}
 
-	args := s.logger.ArgsFromMap(keyValsMap)
+	record.Attrs(func(attr slog.Attr) bool {
+		args = append(args, LoggerArgument{Key: attr.Key, Value: attr.Value})
+		return true
+	})
 
 	// Wrapping args inside another slice to match [][]LoggerArgument
 	argsWrapped := [][]LoggerArgument{args}


### PR DESCRIPTION
Fixes #611

## What

The `SlogHandler` collected slog attrs into a `map[string]any` before handing them to the logger. Because Go randomizes map iteration order, the colorful (text) formatter printed the key-value pairs in a different order on every call. This makes structured logs hard to scan and diff.

This PR:

- Rewrites `SlogHandler.Handle` to build the arguments in the order they were supplied: attrs bound via `WithAttrs` first, then the record's own attrs, each in insertion order. This matches the behavior of slog's own `TextHandler`, so output is now stable and predictable. (`json.Marshal` already sorted the JSON formatter's keys, so this only affects text output.)
- Adds an opt-in `SortArguments` option on the `Logger` (with the usual `WithSortArguments(...)` builder) for users who prefer alphabetical output. It is off by default, so the original order is kept unless explicitly enabled. The sort is applied in `combineArgs`, so it works consistently for both the variadic `Args(...)` path and the slog path.

This follows the approach agreed on in #611 (option 3: keep original order by default, offer an alphabetical-sort toggle).

## Tests

- `TestSlogHandlerPreservesArgumentOrder` — non-alphabetical keys stay in supplied order (WithAttrs then record attrs).
- `TestSlogHandlerSortArgumentsSortsAlphabetically` — `WithSortArguments()` produces alphabetical order.
- `TestLoggerWithSortArguments` — the builder sets the field and does not mutate the receiver.

`go test -race ./...` passes across the module; `gofmt` and `go vet` are clean. Public signatures are unchanged (a field and a `With*` method are added), and `ArgsFromMap` is left untouched.

Happy to add a small `_examples/logger` entry for the new option if you'd like it in the generated docs.